### PR TITLE
Replaced django-staticfiles 0.2.0 with django.contrib.staticfiles (django 1.3)

### DIFF
--- a/requirements/mkii.txt
+++ b/requirements/mkii.txt
@@ -5,7 +5,7 @@
 Django==1.3
 
 django-debug-toolbar==0.8.3
-django-staticfiles==0.2.0
+# django-staticfiles==0.2.0
 
 django-uni-form==0.7.0
 

--- a/settings.py
+++ b/settings.py
@@ -150,10 +150,11 @@ PREREQ_APPS = [
     "django.contrib.messages",
     "django.contrib.humanize",
     "django.contrib.flatpages",
+    "django.contrib.staticfiles",
     
     # external
     "notification", # must be first
-    "staticfiles",
+#    "staticfiles",
     "uni_form",
     "pagination",
     "django_extensions",


### PR DESCRIPTION
Warning, this is not tested locally.
