### PR TITLE
More staticfiles version bump issues

### DIFF
--- a/urls.py
+++ b/urls.py
@@ -80,5 +80,5 @@ urlpatterns += patterns('',
 
 if settings.SERVE_MEDIA:
     urlpatterns += patterns("",
-        url(r"", include("staticfiles.urls")),
+        url(r"", include("django.contrib.staticfiles.urls")),
     )


### PR DESCRIPTION
To fix issues that came up on Djangozoom. It worked locally before this change and after it, though, so it must just be a production issue.
