### PR TITLE
Switching the links to the github project and issues to the opencomparison

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -14,7 +14,7 @@
             {% trans "We can't find it!  Oh no!  The page isn't here!" %}
             </p>
             <p>
-           {% trans "If it's our fault, would you please do us a favor and" %} <a href="http://github.com/djangopackages/djangopackages/issues">{% trans "create a ticket?" %}</a></div>
+           {% trans "If it's our fault, would you please do us a favor and" %} <a href="http://github.com/opencomparison/opencomparison/issues">{% trans "create a ticket?" %}</a></div>
             </p>            
         </div>        
     </div>

--- a/templates/about/about.html
+++ b/templates/about/about.html
@@ -36,8 +36,8 @@
     <h2>Can I help?</h2>
     
     <p>
-        Django Packages is an volunteer based <a href="http://github.com/djangopackages/djangopackages">open source effort</a>.
-        Please <a href="http://github.com/djangopackages/djangopackages/issues">submit any ideas or issues</a> and 
+        Django Packages is an volunteer based <a href="http://github.com/opencomparison/opencomparison">open source effort</a>.
+        Please <a href="http://github.com/opencomparison/opencomparison/issues">submit any ideas or issues</a> and 
         also fork and submit back patches and enhancements.
     </p>
 

--- a/templates/account/verification_sent.html
+++ b/templates/account/verification_sent.html
@@ -11,7 +11,7 @@
         We have sent you an e-mail to <b>{{ email }}</b> for verification.
         Follow the link provided to finalize the signup process. If you do not receive it
         within a few minutes,
-        <a href="http://github.com/djangopackages/djangopackages/issues">submit a ticket.</a>.
+        <a href="http://github.com/opencomparison/opencomparison/issues">submit a ticket.</a>.
                 
         {% endblocktrans %}</p>
     <p><a href="{{ success_url }}">{% trans "Go back" %}</a></p>


### PR DESCRIPTION
Switching the links to the github project and issues to the opencomparison project instead of djangopackages
