### PR TITLE
In HTTPS calls to RTD (on HTTP) in js are blocked.

### DIFF
--- a/static/js/rtd.js
+++ b/static/js/rtd.js
@@ -6,7 +6,7 @@ $.fn.checkRTD = function(options){
     return this.each(function(){
         var ele = $(this);
         var slug = ele.attr('rel');
-        var url = "http://readthedocs.org/api/v1/build/" + slug + "/?format=jsonp";
+        var url = "https://readthedocs.org/api/v1/build/" + slug + "/?format=jsonp";
         $.ajax({
             url: url,
             dataType: 'jsonp',


### PR DESCRIPTION
External JavaScript will be blocked by default as insecure content. Thankfully, because RTD is somewhat awesome it supports HTTPS, so its a very simple change. See below for the issue without the change.

![Screen Shot 2013-02-23 at 13 40 59](https://f.cloud.github.com/assets/48211/188077/b1bc4fa4-7dbe-11e2-95d1-4141745eebb4.png)
