### PR TITLE
Fetch commits as well as metadata when creating or updating a package.

### DIFF
--- a/package/views.py
+++ b/package/views.py
@@ -69,6 +69,7 @@ def add_package(request, template_name="package/package_form.html"):
         new_package.last_modified_by = request.user
         new_package.save()
         new_package.fetch_metadata()
+        new_package.fetch_commits()
 
         # stick in package_extender form processing
         for package_extender in package_extenders:
@@ -118,6 +119,7 @@ def update_package(request, slug):
 
     package = get_object_or_404(Package, slug=slug)
     package.fetch_metadata()
+    package.fetch_commits()
     messages.add_message(request, messages.INFO, 'Package updated successfully')
 
     return HttpResponseRedirect(reverse("package", kwargs={"slug": package.slug}))


### PR DESCRIPTION
Currently only the metadata will be fetched/refreshed when a package is created/updated.
This change would ensure that the commit history would also be fetched.

There's presumably still something unrelated to this fix that's wrong with fetching the github commit history, although it seems to me that it's more likely to be something that's stopping the scheduled task from running, than the commit fetching itself being wrong, as I was able to run a package update with this fix and get the latest few commits from github to correctly update on a package.

(Also note the oddity that some github packages do seem to be updating the commit history properly, where others have flatlined, eg. [here](https://www.djangopackages.com/grids/g/api/))
