### PR TITLE
Adds github auth settings for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
 before_install:
   - export PIP_USE_MIRRORS=true
   - export PIP_INDEX_URL=https://simple.crate.io/
+  - export GITHUB_USERNAME=someuserthatdoesnotexist
+  - export GITHUB_PASSWORD=anything
 install:
   - pip install -r requirements.txt
 script:


### PR DESCRIPTION
Since the github package repo seems to require authentication for any requests,
even authenticated, public info - adding these variables to the execution env
passes the tests, despite being invalid.

Also #200
