### PR TITLE
Export env vars before running tests instead of before install.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: python
 python:
   - "2.7"
-before_install:
-  - export PIP_USE_MIRRORS=true
-  - export PIP_INDEX_URL=https://simple.crate.io/
 install:
   - pip install -r requirements.txt
 script:
+  - export PIP_USE_MIRRORS=true
+  - export PIP_INDEX_URL=https://simple.crate.io/
   - python manage.py test --settings=settings.test


### PR DESCRIPTION
This makes the Travis setup a little cleaner. Just being nitpicky here.
