### PR TITLE
Added libmemcached in Mac OSX section & troubleshooting.rst file changed

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -14,6 +14,7 @@ Download and install setuptools from http://pypi.python.org/pypi/setuptools.  Se
 
     easy_install pip
     pip install virtualenv
+    brew install libmemcached
 
 Ubuntu (10+ /  Lucid or Higher)
 --------------------------------
@@ -42,7 +43,7 @@ Open up a command prompt.  Install pip and virtualenv::
 
     easy_install pip
     pip install virtualenv
-    
+
 Other operating systems (including various Linux flavors)
 ---------------------------------------------------------
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -35,6 +35,15 @@ Install the appropriate systemwide package.  For example, on Ubuntu do:
 
 If this doesn't work, please let us know (create an issue at http://github.com/opencomparison/opencomparison/issues)
 
+
+fatal error: 'libmemcached/memcached.h' file not found
+------------------------------------------------------
+
+if you are getting something like ./_pylibmcmodule.h:42:10: fatal error: 'libmemcached/memcached.h' file not found. Then you need to install libmemcached::
+
+    brew install libmemcached
+
+
 Other problems
 --------------
 


### PR DESCRIPTION
I tried to install/build open comparison  without `libmemcached` package and get following error message.

'''In file included from _pylibmcmodule.c:34:

./_pylibmcmodule.h:42:10: fatal error: 'libmemcached/memcached.h' file not found
# include <libmemcached/memcached.h>

```
     ^
```

1 error generated.

error: command 'cc' failed with exit status 1''' 

then I installed `libmemcached` using brew. and it works.
