### PR TITLE
change crate.io references to pypi.python.org

### DIFF
--- a/templates/package/package.html
+++ b/templates/package/package.html
@@ -82,7 +82,7 @@
        <div class="panel-body">
           <p><a href="{{ package.pypi_url }}">{{ package.pypi_url }}</a></p>
           <p>
-            <a href="https://crate.io/packages/{{ package.pypi_name }}/" rel="nofollow"><img src="https://pypip.in/d/{{ package.pypi_name }}/badge.png"></a>
+            <a href="https://pypi.python.org/pypi/{{ package.pypi_name }}/" rel="nofollow"><img src="https://pypip.in/d/{{ package.pypi_name }}/badge.png"></a>
           </p>
         </div>
         <table class="table">


### PR DESCRIPTION
Remove crate.io references on package.html and change to pypi.python.org.

crate.io domain was sold to bigdata company

http://www.reddit.com/r/Python/comments/1wcp93/what_happened_to_crateio/

crateio/crate.io#18

I think at the moment there is no substitute for crate.io.
