### PR TITLE
Pin redis image

### DIFF
--- a/compose/redis/Dockerfile
+++ b/compose/redis/Dockerfile
@@ -1,3 +1,3 @@
-FROM redis
+FROM redis:3.2
 COPY redis.conf /usr/local/etc/redis/redis.conf
 CMD ["redis-server", "/usr/local/etc/redis/redis.conf" ]

--- a/dev.yml
+++ b/dev.yml
@@ -33,4 +33,4 @@ services:
       - .env.local
 
   redis:
-    image: redis:3.0
+    build: ./compose/redis


### PR DESCRIPTION
Pin redis base image in ./compose/redis/Dockerfile to 3.2 (complying with the one in dev.yml).

Closes #472.