### PR TITLE
Upgrade postgres to 9.6

### DIFF
--- a/compose/postgres/Dockerfile
+++ b/compose/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.4
+FROM postgres:9.6
 
 # add backup scripts
 ADD backup.sh /usr/local/bin/backup


### PR DESCRIPTION
The following issue was logged locally:

```shell
postgres_1  | FATAL:  database files are incompatible with server
postgres_1  | DETAIL:  The data directory was initialized by PostgreSQL version 9.4, which is not compatible with this version 9.6.2.
```

Seems like the changeset would require careful production DB migration once merged in and deployed. 

Closes #475.