### PR TITLE
Small changes needed to build Docker locally

### DIFF
--- a/compose/django/Dockerfile-dev
+++ b/compose/django/Dockerfile-dev
@@ -5,6 +5,7 @@ ENV PYTHONUNBUFFERED 1
 # Requirements have to be pulled and installed here, otherwise caching won't work
 COPY ./requirements.txt /requirements.txt
 
+RUN pip install --upgrade pip
 RUN pip install -r /requirements.txt
 
 COPY ./compose/django/entrypoint.sh /entrypoint.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ django-storages==1.5.1
 djangorestframework==3.4.0
 feedparser==5.2.1
 github3.py==0.9.6
-uwsgi==2.0.14
+uwsgi==2.0.17.1
 httplib2==0.10.3
 logutils==0.3.3
 mimeparse==0.1.3


### PR DESCRIPTION
Hi, I'm submitting a small PR with my changes because I wasn't initially able to build the project locally using Docker. 

I initially got this error trace when trying to build using Docker:

```
Command "/usr/local/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-zkat9xjc/uwsgi/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-record-lrubmm5h/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-install-zkat9xjc/uwsgi/
You are using pip version 10.0.1, however version 18.0 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

Here are the changes that I made:

1. upgraded pip version (this seems optional)

1. upgrade uwsgi version

- this was mandatory, Docker wouldn't complete with the current uWSGI version. [Here](https://github.com/gliderlabs/docker-alpine/issues/158#issuecomment-205401343) is the Github comment that lead me to believe it was the uWSGI version