### PR TITLE
Fixed RTD documentation link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ https://djangopackages.org.
 The Documentation
 -----------------
 
-The documentation is hosted at http://djangopackagesorg.readthedocs.io/en/latest
+The documentation is hosted at http://djangopackages.readthedocs.io/en/latest
 
 License
 -------


### PR DESCRIPTION
It fixes the broken doc link on the readme `http://djangopackagesorg.readthedocs.io/en/latest` it should be `http://djangopackages.readthedocs.io/en/latest` 