### PR TITLE
Update psycopg2 to 2.8.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ httplib2==0.10.3
 logutils==0.3.3
 mimeparse==0.1.3
 oauth2==1.9.0.post1
-psycopg2==2.6.2
+psycopg2==2.8.3
 python-dateutil==2.6.0
 social-auth-core==1.6.0
 social-auth-app-django==2.1.0


### PR DESCRIPTION
## Problem
Version 2.6.2 of psycopg2 throws and error while building image.

## Solution
Updated psycopg2 to latest version 2.8.3, and seems that nothing broke