### PR TITLE
[Documentation] The .env.local is required to run docker-compose build

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,8 +56,8 @@ To download, install and start the local server for development, simply run::
 
     git clone git@github.com:djangopackages/djangopackages.git
     cd djangopackages
-    docker-compose -f dev.yml build
     cp .env.local.example .env.local
+    docker-compose -f dev.yml build
     docker-compose -f dev.yml up
 
 Then point your browser to http://localhost:8000 and start hacking!

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -14,31 +14,43 @@ Main instructions
 
 These instructions install Django Packages on your computer, using Docker.
 
-Git clone the project and build Docker container
-------------------------------------------------
+Git clone the project
+---------------------
 
-Clone the Django Packages project using git, and build the project using docker-compose::
+Clone the Django Packages project using git:
+
+.. code-block:: bash
 
     git clone git@github.com:djangopackages/djangopackages.git
     cd djangopackages
-    docker-compose -f dev.yml build
 
 Set up the development environment
 ----------------------------------
 
-In order to run the project, you need to add a file called ``.env.local``. The file holds all the configurable settings and secrets to run properly.
+In order to run the project, you first need to add a file called ``.env.local``.
+The file holds all the configurable settings and secrets to run properly.
 
-There's an example file available. To get started, copy the file::
+There's an example file available. To get started, copy the file:
+
+.. code-block:: bash
 
     cp .env.local.example .env.local
 
+Build Docker container
+----------------------
+
+Now build the project using docker-compose:
+
+.. code-block:: bash
+
+    docker-compose -f dev.yml build
 
 Running the project
 -------------------
 
 To start the project, run:
 
-.. sourcecode:: bash
+.. code-block:: bash
 
     docker-compose -f dev.yml up
 
@@ -47,7 +59,9 @@ Then point your browser to http://localhost:8000 and start hacking!
 Give yourself an admin account on the site
 ------------------------------------------
 
-Create a Django superuser for yourself, replacing joe with your username/email::
+Create a Django superuser for yourself, replacing joe with your username/email:
+
+.. code-block:: bash
 
     docker-compose -f dev.yml run django python manage.py createsuperuser --username=joe --email=joe@example.com
 


### PR DESCRIPTION
The .env.local is required to run docker-compose build but the documentation lists the docker-compose build first.

Running build first as mentioned in the quickstart and main documetation returns this error:
```
~/dev/python/djangopackages(master*) » docker-compose -f dev.yml build                                                                                       
ERROR: Couldn't find env file: /Users/hugo/dev/python/djangopackages/.env.local
```

After copying the file there are no issues:
```
~/dev/python/djangopackages(master*) » cp .env.local.example .env.local                                                                                      
------------------------------------------------------------
~/dev/python/djangopackages(master*) » docker-compose -f dev.yml build                                                                                       
Building postgres
Step 1/7 : FROM postgres:9.4
 ---> d1b08fdd94ed
 ...
```

This updates the quick start in the readme and the main documentation. The `.. code-block:: bash` tags were also added to all console snippets in the main documentation.
