### PR TITLE
Remove whitenoise from requirements since we are not using it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,6 @@ social-auth-app-django==2.1.0
 requests==2.22.0
 shortuuid==0.4.3
 six==1.10.0
-whitenoise==3.2.2
 
 # Redis support
 django-redis==4.6.0


### PR DESCRIPTION
White noise causes pyup to fail due to a security update. Since we are not using it this PR removes it