### PR TITLE
Fix #534 Remove deprecated stuff and use new ones

### DIFF
--- a/core/management/commands/load_dev_data.py
+++ b/core/management/commands/load_dev_data.py
@@ -1,16 +1,16 @@
 from sys import stdout
+from importlib import import_module
 
 from django.conf import settings
-from django.core.management.base import CommandError, NoArgsCommand
-from django.utils.importlib import import_module
+from django.core.management.base import BaseCommand
 from django.utils.module_loading import module_has_submodule
 
 
-class Command(NoArgsCommand):
-    
+class Command(BaseCommand):
+
     help = "Import development data for local dev"
-    
-    def handle(self, *args, **options): 
+
+    def handle(self, *args, **options):
         print("Commencing dev data import", file=stdout)
 
         for app in settings.INSTALLED_APPS:


### PR DESCRIPTION
NoArgsCommand class is deprecated since django 1.10 also import_module is removed since django 1.9 due to python's builtin importlib. I updated the load_dev_data management command to use new stuff.

This PR fixes https://github.com/djangopackages/djangopackages/issues/534