### PR TITLE
Added target blank to repo and pypi links

### DIFF
--- a/templates/package/package.html
+++ b/templates/package/package.html
@@ -181,10 +181,10 @@
                 <p>{{ package.documentation_url|urlize }}</p>
 
                 <h3>PyPi</h3>
-                <p><a href="{{ package.pypi_url }}">{{ package.pypi_url }}</a></p>
+                <p><a href="{{ package.pypi_url }}" target="_blank">{{ package.pypi_url }}</a></p>
 
                 <h3>Repo</h3>
-                <p><a href="{{ package.repo_url }}">{{ package.repo_url }}</a></p>
+                <p><a href="{{ package.repo_url }}" target="_blank">{{ package.repo_url }}</a></p>
 
 
                 <h3>{% trans "Comparison Grids" %}</h3>


### PR DESCRIPTION
Added target="_blank" to PyPi and Repo links in the package view. 
Currently browsing packages is a bit annoying when you browsing more of them and you constantly need to right click and open in the new tab.

