### PR TITLE
Add docker-compose logging configurations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,12 @@ services:
       - media:/data/media
     command: /start.sh
     env_file: .env
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "400m"
+        max-file: "5"
+        compress: true
 
   django-b:
     build:
@@ -33,6 +39,12 @@ services:
       - media:/data/media
     command: /start.sh
     env_file: .env
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "400m"
+        max-file: "5"
+        compress: true
 
   postgres:
     build: ./compose/postgres
@@ -40,6 +52,12 @@ services:
       - /data/djangopackages/postgres:/var/lib/postgresql/data
       - /data/djangopackages/backups:/backups
     env_file: .env
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "600m"
+        max-file: "5"
+        compress: true
 
   caddy:
     build: ./compose/caddy
@@ -54,6 +72,18 @@ services:
       - "80:80"
       - "443:443"
     env_file: .env
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "600m"
+        max-file: "5"
+        compress: true
 
   redis:
     build: ./compose/redis
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "5"
+        compress: true


### PR DESCRIPTION
## Description:

- Limit containers max log size
- Enable containers log rotation
- Enable containers log compression

## Rationale

By default, [`docker-compose`](https://docs.docker.com/compose/compose-file/#logging) uses json-file as the log driver.
The [`json-file`](https://docs.docker.com/config/containers/logging/json-file/) is configured by default to:
- Allow the container to generate a log file with unlimited size. In practice, the maximum size of the log file will be the maximum size of the disk space.
- not rotate the log files.
- not compress the log files.

Letting the log files grow indefinitely does not seem like a correct choice because, at some point, we will end up completely filling our disk in the middle of the night.

With the configuration of this pull-request and if log compression disabled, the total sum of the maximum sizes of all logs generated would be ~10.5GB

