### PR TITLE
Bump django and httplib version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2017.4.17
 chardet==3.0.2
 coverage==4.3.4
-Django==2.2.8
+Django==2.2.13
 django-braces==1.9.0
 django-crispy-forms==1.8.0
 django-debug-toolbar==2.0
@@ -19,7 +19,7 @@ djangorestframework==3.10.3
 feedparser==5.2.1
 github3.py==0.9.6
 uwsgi==2.0.17.1
-httplib2==0.10.3
+httplib2==0.18.0
 logutils==0.3.3
 mimeparse==0.1.3
 oauth2==1.9.0.post1


### PR DESCRIPTION
Bump Django and Httplib versions substitute PRs https://github.com/djangopackages/djangopackages/pull/589
https://github.com/djangopackages/djangopackages/pull/586


