### PR TITLE
Reorganizes README badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,20 +7,17 @@ Django Packages helps you easily identify and compare good apps, frameworks, plu
 Badges
 ------
 
-.. image:: https://pyup.io/repos/github/djangopackages/djangopackages/shield.svg
-     :target: https://pyup.io/repos/github/djangopackages/djangopackages/
-     :alt: Updates
-
-.. image:: https://pyup.io/repos/github/djangopackages/djangopackages/python-3-shield.svg
-     :target: https://pyup.io/repos/github/djangopackages/djangopackages/
-     :alt: Python 3
-
 .. image:: https://travis-ci.org/djangopackages/djangopackages.svg?branch=master
-        :target: https://secure.travis-ci.org/djangopackages/djangopackages
+     :target: https://secure.travis-ci.org/djangopackages/djangopackages
 
 .. image:: https://readthedocs.org/projects/djangopackagesorg/badge/?version=latest
      :target: http://djangopackagesorg.readthedocs.io/en/latest/?badge=latest
      :alt: Documentation Status
+
+.. image:: https://pyup.io/repos/github/djangopackages/djangopackages/shield.svg
+     :target: https://pyup.io/repos/github/djangopackages/djangopackages/
+     :alt: Updates
+
 
 Features
 --------


### PR DESCRIPTION
Changes:
1. Removes `Python3 blockers` badge, like this project is already using Python3, why does it show any blockers?
2. Puts more important badges first, then PyUP with less important info