### PR TITLE
🚜 Refactors grid template cache to dump on save/delete

### DIFF
--- a/grid/models.py
+++ b/grid/models.py
@@ -1,9 +1,10 @@
 from django.core.cache import cache
+from django.core.cache.utils import make_template_fragment_key
 from django.db import models
 from django.urls import reverse
 
 from core.models import BaseModel
-from grid.utils import make_template_fragment_key
+from grid.utils import make_template_fragment_key as grid_make_template_fragment_key
 from package.models import Package
 from django.utils.translation import gettext_lazy as _
 
@@ -54,9 +55,16 @@ class Grid(BaseModel):
     def get_absolute_url(self):
         return reverse("grid", args=[self.slug])
 
+    def get_detail_template_cache_key(self):
+        return grid_make_template_fragment_key("detail_template_cache", [str(self.pk)])
+
     def clear_detail_template_cache(self):
-        key = make_template_fragment_key("detail_template_cache", [str(self.pk)])
+        key = self.get_detail_template_cache_key()
         cache.delete(key)
+
+        # delete grid template cache
+        template_key = make_template_fragment_key("html_grid_detail_outer", [str(self.pk)])
+        cache.delete(template_key)
 
     class Meta:
         ordering = ['title']

--- a/grid/views.py
+++ b/grid/views.py
@@ -209,11 +209,12 @@ def delete_grid_package(request, id, template_name="grid/edit_feature.html"):
 
     # do not need to check permission via profile because
     # we default to being strict about deleting
-    package = get_object_or_404(GridPackage, id=id)
-    Element.objects.filter(grid_package=package).delete()
-    package.delete()
+    grid_package = get_object_or_404(GridPackage, id=id)
+    grid_package.grid.clear_detail_template_cache()
+    Element.objects.filter(grid_package=grid_package).delete()
+    grid_package.delete()
 
-    return HttpResponseRedirect(reverse('grid', kwargs={'slug': package.grid.slug}))
+    return HttpResponseRedirect(reverse('grid', kwargs={'slug': grid_package.grid.slug}))
 
 
 @login_required
@@ -272,6 +273,7 @@ def add_grid_package(request, grid_slug, template_name="grid/add_grid_package.ht
                         package=package
                     )
             grid_package.save()
+            grid.clear_detail_template_cache()
             redirect = request.POST.get('redirect', '')
             if redirect:
                 return HttpResponseRedirect(redirect)


### PR DESCRIPTION
I was fighting cache issues and made a small refactor to help address it. The grid cache gets dumped updates, but we'll have to test it on large grids to see if we have issues. 