### PR TITLE
Enable Django Debug Toolbar.

### DIFF
--- a/settings/base.py
+++ b/settings/base.py
@@ -273,13 +273,7 @@ if DEBUG:
     MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
     INSTALLED_APPS += ("debug_toolbar",)
 
-    INTERNAL_IPS = ("127.0.0.1",)
-
-    DEBUG_TOOLBAR_CONFIG = {
-        "INTERCEPT_REDIRECTS": False,
-        "SHOW_TEMPLATE_CONTEXT": True,
-    }
-    x = 1
+    DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": lambda _request: DEBUG}
 
 ADMIN_URL_BASE = environ.get("ADMIN_URL_BASE", r"^admin/")
 

--- a/urls.py
+++ b/urls.py
@@ -71,5 +71,9 @@ urlpatterns = [
     # url(r'^reports/', include('reports.urls', namespace='reports')),
 ]
 
+if settings.DEBUG:
+    import debug_toolbar
+
+    urlpatterns.append(path("__debug__/", include(debug_toolbar.urls)))
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Django Debug Toolbar already existed but was not appearing in DEBUG mode. References discussion #685
There were mainly two reasons for it to not appear:

- It was not included in urls.py
- Debug toolbar checks if the remote address is in the list of `INTERNAL_IPS` or not and then it is enabled. Since we use docker it was not showing. The detailed explanation can be seen here - https://stackoverflow.com/a/50492036.