### PR TITLE
Add missing postgres env vars to env example

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -6,3 +6,5 @@ GITHUB_USERNAME=your-bot
 POSTGRES_DB=djangopackages
 POSTGRES_PASSWORD=djangopackages
 POSTGRES_USER=djangopackages
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432


### PR DESCRIPTION
Hello!

I recently started to get an error that was blocking my local development with docker: `Postgres is unavailable - sleeping`

I wasn't getting this error when I ran this project a week ago. So after doing some investigation, I was able to run the project again after adding `POSTGRES_HOST` and `POSTGRES_PORT` to `.env.local`. I believe this error was introduced because we forgot to update `.env.example` after this change https://github.com/djangopackages/djangopackages/commit/7d33a613dfc4df9ce48cded8a1d4d046dd6a1352

So I'm creating this PR to include the missing postgres env vars to `.env.local.example`, in order to have everything properly configured before following the README quickstart step  `cp .env.local.example .env.local`