### PR TITLE
Issue/646 - Add filters to Grid

### DIFF
--- a/static/css/grid.css
+++ b/static/css/grid.css
@@ -20,13 +20,13 @@ div#body {
     margin-bottom: 0 !important;
     /* table-layout: fixed; */
 }
-.dataTables_filter, 
+.dataTables_filter,
 .dataTables_info {
     margin: 8px 0;
 }
 td.package-name {
-    font-weight: bold; 
-    color: #000000; 
+    font-weight: bold;
+    color: #000000;
     background-color: #E0FBE9;
 }
 #grid-toggle a {
@@ -36,4 +36,19 @@ td.package-name {
     display: inline-block;
     text-align: center;
     font-weight: bold;
+}
+.grid-filters {
+    margin-bottom: 20px;
+}
+.grid-filter {
+    display: flex;
+    align-items: center;
+    margin-bottom: 5px;
+}
+.grid-filter__checkbox {
+    margin: 0 !important;
+}
+.grid-filter__label {
+    margin: 0 0 0 5px;
+    font-size: 12px;
 }

--- a/templates/grid/grid_detail.html
+++ b/templates/grid/grid_detail.html
@@ -28,7 +28,7 @@
     </h2>
   </div>
 </div>
-{% cache 300 html_grid_detail_outer grid.pk %}
+{% cache 300 html_grid_detail_outer grid.pk filters %}
 <div class="row">
   <div class="col-lg-{% if features %}3{% else %}6{% endif %}">
 
@@ -97,6 +97,24 @@
         {% endif %}
     </div>
   {% endif %}
+</div>
+
+<div class="row grid-filters">
+    <div class="col-lg-12">
+        <h3>{% trans "Filter results" %}</h3>
+    </div>
+    <div class="col-lg-12">
+        <div class="grid-filter">
+            <input class="grid-filter__checkbox" type="checkbox" value="python3" id="python3-filter">
+            <label class="grid-filter__label" for="python3-filter">Python 3</label>
+        </div>
+    </div>
+    <div class="col-lg-12">
+        <div class="grid-filter">
+            <input class="grid-filter__checkbox" type="checkbox" value="stable" id="stable-filter">
+            <label class="grid-filter__label" for="stable-filter">Stable</label>
+        </div>
+    </div>
 </div>
 
 <!-- Grid is not inside of a Bootstrap grid row because it needs max width. -->
@@ -351,6 +369,58 @@
                  $(window).resize(resizeFixed);
                  $(window).scroll(scrollFixed);
                  resizeFixed();
+
+                 // Parse URL query strings into an array
+                 function getQueryStringParams() {
+                     const params = [];
+                     const queryStringStart = window.location.href.indexOf("?");
+                     const rawParams = queryStringStart > -1
+                        ? window.location.href.slice(queryStringStart + 1).split("&")
+                        : [];
+                     for(let i = 0; i < rawParams.length; i++) {
+                         const param = rawParams[i].split("=");
+                         params.push([param[0], param[1]]);
+                     }
+                     return params;
+                 }
+
+                // handle filtering
+                $(".grid-filter__checkbox").each(function() {
+                    const qs = getQueryStringParams()
+
+                    // tick filters already present on pageload
+                    for(let i = 0; i < qs.length; i++) {
+                        if (qs[i][0] === this.value && qs[i][1] === "1") {
+                            $(this).prop("checked", true);
+                        }
+                    }
+                    // handle redirect when checking/unchecking filters
+                    $(this).click(function() {
+                        const qsArr = [];
+                        if ($(this).is(":checked")) {
+                            let found = false;
+                            for(let i = 0; i < qs.length; i++) {
+                                if (qs[i][0] === this.value) {
+                                    found = true;
+                                    qsArr.push(this.value + "=1");
+                                } else {
+                                    qsArr.push(qs[i][0] + "=" + qs[i][1]);
+                                }
+                            }
+                            if (!found) {
+                                qsArr.push(this.value + "=1");
+                            }
+                        } else {
+                            for(let i = 0; i < qs.length; i++) {
+                                if (qs[i][0] !== this.value) {
+                                    qsArr.push(qs[i][0] + "=" + qs[i][1]);
+                                }
+                            }
+                        }
+                        const qsStr = qsArr.length ? "?" + qsArr.join("&") : "";
+                        $(location).attr('href', window.location.pathname + qsStr);
+                    });
+                });
 
             });
         </script>


### PR DESCRIPTION
Adds two filters to grid: **python3** and **stable**.
Refers to: #646

![2021-09-25--07-59-15](https://user-images.githubusercontent.com/15188528/134769086-9cc28167-5718-426b-93c1-6bf328daa4ca.png)

**Changelog:**
- Add filter section in the grid template.
- Add JS to handle query strings, filter change and redirect.
- Add filter variant to the cache template tag.
- Add CSS to render the filter section.
- Add filter to grid detail view.
- Add filter whitelist to prevent cache overflow.
- Serialize sorted filters to prevent cache duplication.

**Important Note:**

With those 2 filters, the total of different templates rendered for each grid increases up to four, one for each possible filter combination.

Using the Authentication grid as an example:
1. `python3=False` and `stable=False` - *all = 117 (current)*
2. `python3=True` and `stable=False` - *python3 = 67 (+57%)*
2. `python3=True` and `stable=True` - *stable python3 = 41 (+35%)*
2. `python3=False` and `stable=True` - *stable = 44 (+38%)*

As a result, the **grid template cache might increase up to 130%**.
