### PR TITLE
⬆️🐘 Upgrade dev Postgres from 9.4 to 13

### DIFF
--- a/compose/postgres/Dockerfile
+++ b/compose/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.4
+FROM postgres:13
 
 # add backup scripts
 ADD backup.sh /usr/local/bin/backup


### PR DESCRIPTION
Fixes #735 

This upgrades our default (dev.yml) Postgres database from 9.4 to 13.

I highly suggest changing the Dockerfile to use 9.4 to do a backup.sh then switch it back to 13 and run restore in case of any loss. 