### PR TITLE
:tractor: Updates pypi links to newer link locations

### DIFF
--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -15,26 +15,22 @@ def test_oc_slugify():
 
 
 def test_get_pypi_url_success(requests_mock):
-    requests_mock.get("https://pypi.python.org/pypi/django", status_code=200)
-    requests_mock.get("https://pypi.python.org/pypi/django-uni-form", status_code=200)
-    requests_mock.get("https://pypi.python.org/pypi/Django Uni Form", status_code=404)
-
+    requests_mock.get("https://pypi.org/project/django/", status_code=200)
+    requests_mock.get("https://pypi.org/project/django-uni-form/", status_code=200)
+    requests_mock.get("https://pypi.org/project/Django Uni Form/", status_code=404)
     lst = (
-        ('django', 'https://pypi.python.org/pypi/django'),
-        ('Django Uni Form', 'https://pypi.python.org/pypi/django-uni-form'),
+        ('django', 'https://pypi.org/project/django/'),
+        ('Django Uni Form', 'https://pypi.org/project/django-uni-form/'),
     )
     for l in lst:
         assert utils.get_pypi_url(l[0].lower()) == l[1].lower()
 
 
 def test_get_pypi_url_fail(requests_mock):
-    requests_mock.get("https://pypi.python.org/pypi/coldfusion is not here", status_code=404)
-    requests_mock.get("https://pypi.python.org/pypi/ColdFusion is not here", status_code=404)
-    requests_mock.get("https://pypi.python.org/pypi/coldfusion-is-not-here", status_code=404)
-    requests_mock.get("https://pypi.python.org/pypi/Coldfusion%20Is%20Not%20Here", status_code=404)
-    requests_mock.get("https://pypi.python.org/pypi/php is not here", status_code=404)
-    requests_mock.get("https://pypi.python.org/pypi/Php Is Not Here", status_code=404)
-    requests_mock.get("https://pypi.python.org/pypi/php-is-not-here", status_code=404)
+    requests_mock.get("https://pypi.org/project/Coldfusion%20Is%20Not%20Here/", status_code=404)
+    requests_mock.get("https://pypi.org/project/coldfusion-is-not-here/", status_code=404)
+    requests_mock.get("https://pypi.org/project/php%20is%20not%20here/", status_code=404)
+    requests_mock.get("https://pypi.org/project/php-is-not-here/", status_code=404)
 
     lst = (
         'ColdFusion is not here',

--- a/core/utils.py
+++ b/core/utils.py
@@ -19,7 +19,7 @@ def oc_slugify(value):
 def get_pypi_url(title):
     title = title.strip()
     for value in [oc_slugify(title.lower()), oc_slugify(title), title, title.lower(), title.title(), ]:
-        value = 'https://pypi.python.org/pypi/' + value
+        value = f"https://pypi.org/project/{value}/"
         r = requests.get(value)
         if r.status_code == 200:
             return value

--- a/grid/tests/test_views.py
+++ b/grid/tests/test_views.py
@@ -211,7 +211,7 @@ class FunctionalGridTest(TestCase):
             'repo_url': 'http://www.example.com',
             'title': 'Test package',
             'slug': 'test-package',
-            'pypi_url': 'http://pypi.python.org/pypi/mogo/0.1.1',
+            'pypi_url': 'https://pypi.org/project/mogo/0.1.1/',
             'category': 1
         }, follow=True)
         self.assertEqual(Package.objects.count(), count + 1)

--- a/package/models.py
+++ b/package/models.py
@@ -105,6 +105,9 @@ class Package(BaseModel):
         if "https://pypi.python.org/pypi/" in name:
             name = name.replace("https://pypi.python.org/pypi/", "")
 
+        if "https://pypi.org/project/" in name:
+            name = name.replace("https://pypi.org/project/", "")
+
         if not name.startswith("http"):
             name = f"https://pypi.org/project/{name}"
 
@@ -185,9 +188,8 @@ class Package(BaseModel):
     def fetch_pypi_data(self, *args, **kwargs):
         # Get the releases from pypi
         if self.pypi_url.strip() and self.pypi_url not in ["http://pypi.python.org/pypi/", "https://pypi.python.org/pypi/"]:
-
             total_downloads = 0
-            url = f"https://pypi.python.org/pypi/{self.pypi_name}/json"
+            url = f"https://pypi.org/pypi/{self.pypi_name}/json"
             response = requests.get(url)
             if settings.DEBUG:
                 if response.status_code not in (200, 404):

--- a/package/tests/data.py
+++ b/package/tests/data.py
@@ -25,7 +25,7 @@ def load():
         title='Django CMS',
         created_by=None,
         repo_watchers=967,
-        pypi_url='http://pypi.python.org/pypi/django-cms',
+        pypi_url='https://pypi.org/project/django-cms/',
         pypi_downloads=26257,
         last_modified_by=None,
         repo_url='https://github.com/divio/django-cms',

--- a/package/tests/test_repos.py
+++ b/package/tests/test_repos.py
@@ -62,6 +62,7 @@ https://django-audit.googlecode.com/hg/
 tyrion/django-autocomplete/
 http://code.google.com/p/django-autocomplete/
 http://pypi.python.org/pypi/django-autoreports
+https://pypi.org/project/django-autoreports/
 http://code.google.com/p/django-basic-tumblelog/
 schinckel/django-biometrics/
 discovery/django-bitly/

--- a/static/js/package_form.js
+++ b/static/js/package_form.js
@@ -45,7 +45,7 @@ function package_form(data){
 
 	repo_url.focus();
 
-	pypi_url_g = "http://pypi.python.org/pypi/";
+	pypi_url_g = "https://pypi.org/project/";
 
 	pypi_url.val(pypi_url.val().replace(pypi_url_g,""));
 


### PR DESCRIPTION
This is a follow-up to #721 which fixes/upgrades pypi links to the newer API. This needs more manual testing before it's merged. 