### PR TITLE
Removed floppyforms dependency

### DIFF
--- a/package/forms.py
+++ b/package/forms.py
@@ -1,4 +1,4 @@
-from floppyforms.__future__ import ModelForm, TextInput
+from django.forms import ModelForm, TextInput
 
 from package.models import Category, Package, PackageExample
 

--- a/package/tests/test_models.py
+++ b/package/tests/test_models.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from package.forms import PackageForm
 
 from package.models import Package, Version
 from package.tests import data, initial_data
@@ -90,3 +91,7 @@ class PackageTests(TestCase):
     def test_license_latest(self):
         for p in Package.objects.all():
             self.assertEqual("UNKNOWN", p.license_latest)
+
+    def test_package_form(self):
+        f = PackageForm()
+        assert 'placeholder="ex: https://github.com/django/django"' in str(f)

--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,6 @@ django-crispy-forms
 django-debug-toolbar
 django-environ
 django-extensions
-django-floppyforms
 django-jsonview
 django-reversion
 django-secure

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,8 +50,6 @@ django-environ==0.7.0
     # via -r ./requirements.in
 django-extensions==3.1.3
     # via -r ./requirements.in
-django-floppyforms==1.9.0
-    # via -r ./requirements.in
 django-ipware==4.0.0
     # via django-structlog
 django-jsonview==2.0.0

--- a/settings/base.py
+++ b/settings/base.py
@@ -7,8 +7,6 @@ import warnings
 
 from django.template.defaultfilters import slugify
 
-warnings.filterwarnings('ignore', module='floppyforms', message='Unable to import floppyforms.gis')
-
 env = envmax.Env()
 
 PROJECT_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
@@ -152,7 +150,6 @@ PREREQ_APPS = [
     "crispy_forms",
     "dj_pagination",
     "django_extensions",
-    "floppyforms",
     "rest_framework",
     "reversion",
     "social_django",


### PR DESCRIPTION
`Floppyforms` is currently a dependency but can be replaced by Django's own classes. I added a small test to show that the `attrs` are still correctly passed through to the template for rendering. 