### PR TITLE
Avoid docker image/volume collision by using a namespace

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ To download, install and start the local server for development, simply run::
     docker-compose -f dev.yml build
     docker-compose -f dev.yml up
 
-Then point your browser to http://localhost:8000 and start hacking!
+Then point your browser to http://localhost:18000 and start hacking!
 
 To run tests, run::
 

--- a/dev.yml
+++ b/dev.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: .
       dockerfile: ./compose/django/Dockerfile-dev
+    hostname: django
+    image: djpkg-dev-django
     command: /start-dev.sh
     depends_on:
       - postgres
@@ -12,25 +14,31 @@ services:
     env_file:
       - .env.local
     ports:
-      - "8000:8000"
+      - "18000:8000"
     volumes:
       - .:/app
-      - static:/data/static
-      - media:/data/media
+      - djpkg_static_dev:/data/static
+      - djpkg_media_dev:/data/media
 
   postgres:
     build: ./compose/postgres
+    hostname: postgres
+    image: djpkg-dev-postgres
     env_file:
       - .env.local
+    ports:
+      - "45432:5432"
     volumes:
-      - postgres_data_dev:/var/lib/postgresql/data
-      - postgres_backup_dev:/backups
+      - djpkg_postgres_data_dev:/var/lib/postgresql/data
+      - djpkg_postgres_backup_dev:/backups
 
   redis:
     build: ./compose/redis
+    hostname: redis
+    image: djpkg-dev-redis
 
 volumes:
-  postgres_backup_dev: {}
-  postgres_data_dev: {}
-  media: {}
-  static: {}
+  djpkg_postgres_data_dev: {}
+  djpkg_postgres_backup_dev: {}
+  djpkg_media_dev: {}
+  djpkg_static_dev: {}


### PR DESCRIPTION
## Description

- Add namespace to dev docker images and volumes
- Change the Django runserver port to 18000

## Rationale

The basic idea of this pull-request is to avoid having common names for images and volumes on `dev.yml` so that a potential contributor doesn't have to deal with image name collision issues and docker volumes.

It also changed the port used by runserver from 8000 to 18000 for the same reason.