### PR TITLE
Fix changelog links

### DIFF
--- a/.github/changelog-template.md
+++ b/.github/changelog-template.md
@@ -3,7 +3,7 @@
 {%- if pulls %}
 ### {{ change_type }}
 {%- for pull_request in pulls %}
-- {{ pull_request.title }} ([#{{ pull_request.number }}]({{ pull_request.url }}))
+- {{ pull_request.title }} ([#{{ pull_request.number }}]({{ pull_request.html_url }}))
 {%- endfor -%}
 {% endif -%}
 {% endfor -%}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,57 +2,57 @@
 
 ## [2021-10-27]
 ### Changed
-- Re-add grid id and category in the APIv4 ([#751](https://api.github.com/repos/djangopackages/djangopackages/pulls/751))
+- Re-add grid id and category in the APIv4 ([#751](https://github.com/djangopackages/djangopackages/pull/751))
 
 ## [2021-10-13]
 ### Changed
-- 👕  Lints code with Black ([#748](https://api.github.com/repos/djangopackages/djangopackages/pulls/748))
+- 👕  Lints code with Black ([#748](https://github.com/djangopackages/djangopackages/pull/748))
 
 ## [2021-10-12]
 ### Changed
-- Removed floppyforms dependency ([#745](https://api.github.com/repos/djangopackages/djangopackages/pulls/745))
+- Removed floppyforms dependency ([#745](https://github.com/djangopackages/djangopackages/pull/745))
 
 ## [2021-10-10]
 ### Changed
-- :shirt: Lint our templates ([#744](https://api.github.com/repos/djangopackages/djangopackages/pulls/744))
-- :tractor: Updates pypi links to newer link locations ([#739](https://api.github.com/repos/djangopackages/djangopackages/pulls/739))
+- :shirt: Lint our templates ([#744](https://github.com/djangopackages/djangopackages/pull/744))
+- :tractor: Updates pypi links to newer link locations ([#739](https://github.com/djangopackages/djangopackages/pull/739))
 
 ## [2021-10-09]
 ### Changed
-- :pencil: Friday updates for 2021-10-8 ([#743](https://api.github.com/repos/djangopackages/djangopackages/pulls/743))
+- :pencil: Friday updates for 2021-10-8 ([#743](https://github.com/djangopackages/djangopackages/pull/743))
 
 ## [2021-10-08]
 ### Changed
-- Used lru_cache from functools ([#742](https://api.github.com/repos/djangopackages/djangopackages/pulls/742))
+- Used lru_cache from functools ([#742](https://github.com/djangopackages/djangopackages/pull/742))
 
 ## [2021-10-05]
 ### Changed
-- ✨  Adds management command to help find missing pypi packages ([#738](https://api.github.com/repos/djangopackages/djangopackages/pulls/738))
-- :gear: This fixes our local static volumes ([#737](https://api.github.com/repos/djangopackages/djangopackages/pulls/737))
-- ⬆️🐘 Upgrade dev Postgres from 9.4 to 13 ([#736](https://api.github.com/repos/djangopackages/djangopackages/pulls/736))
+- ✨  Adds management command to help find missing pypi packages ([#738](https://github.com/djangopackages/djangopackages/pull/738))
+- :gear: This fixes our local static volumes ([#737](https://github.com/djangopackages/djangopackages/pull/737))
+- ⬆️🐘 Upgrade dev Postgres from 9.4 to 13 ([#736](https://github.com/djangopackages/djangopackages/pull/736))
 
 ## [2021-10-03]
 ### Changed
-- Log a meaningful error message instead of raising an exception. ([#733](https://api.github.com/repos/djangopackages/djangopackages/pulls/733))
-- Follow-up for Update Trove Classifier for Licenses ([#734](https://api.github.com/repos/djangopackages/djangopackages/pulls/734))
-- Show PyPi in sidebar only if PyPi URL exists. ([#730](https://api.github.com/repos/djangopackages/djangopackages/pulls/730))
+- Log a meaningful error message instead of raising an exception. ([#733](https://github.com/djangopackages/djangopackages/pull/733))
+- Follow-up for Update Trove Classifier for Licenses ([#734](https://github.com/djangopackages/djangopackages/pull/734))
+- Show PyPi in sidebar only if PyPi URL exists. ([#730](https://github.com/djangopackages/djangopackages/pull/730))
 
 ## [2021-10-02]
 ### Changed
-- Invalid profile url in ABSOLUTE_URL_OVERRIDES ([#732](https://api.github.com/repos/djangopackages/djangopackages/pulls/732))
+- Invalid profile url in ABSOLUTE_URL_OVERRIDES ([#732](https://github.com/djangopackages/djangopackages/pull/732))
 
 ## [2021-10-01]
 ### Changed
-- Issue/646 - Add filters to Grid ([#719](https://api.github.com/repos/djangopackages/djangopackages/pulls/719))
+- Issue/646 - Add filters to Grid ([#719](https://github.com/djangopackages/djangopackages/pull/719))
 
 ## [2021-09-30]
 ### Changed
-- :bug: Fix for Incorrect PyPI URLs on some packages  ([#725](https://api.github.com/repos/djangopackages/djangopackages/pulls/725))
-- 🐛  Quick fix to make sure a license exists before trying to work w… ([#724](https://api.github.com/repos/djangopackages/djangopackages/pulls/724))
-- Add Dual license support ([#722](https://api.github.com/repos/djangopackages/djangopackages/pulls/722))
+- :bug: Fix for Incorrect PyPI URLs on some packages  ([#725](https://github.com/djangopackages/djangopackages/pull/725))
+- 🐛  Quick fix to make sure a license exists before trying to work w… ([#724](https://github.com/djangopackages/djangopackages/pull/724))
+- Add Dual license support ([#722](https://github.com/djangopackages/djangopackages/pull/722))
 
 ## [2021-09-26]
 ### Changed
-- 🐘  Package model expansion ([#715](https://api.github.com/repos/djangopackages/djangopackages/pulls/715))
-- Automate changelog updates ([#718](https://api.github.com/repos/djangopackages/djangopackages/pulls/718))
-- Automate contributors updates ([#717](https://api.github.com/repos/djangopackages/djangopackages/pulls/717))
+- 🐘  Package model expansion ([#715](https://github.com/djangopackages/djangopackages/pull/715))
+- Automate changelog updates ([#718](https://github.com/djangopackages/djangopackages/pull/718))
+- Automate contributors updates ([#717](https://github.com/djangopackages/djangopackages/pull/717))


### PR DESCRIPTION
This PR closes the issue #746. I replaced the `pull_request.url`(api url) for `pull_request.html_url` and fixed the links on the changelog.