### PR TITLE
Grid of the Week panel on the Home page

### DIFF
--- a/templates/_homepage.html
+++ b/templates/_homepage.html
@@ -103,5 +103,18 @@
 
     </div>
     <div class="row">
+          <!-- start GOTW panel -->
+          {% if gotw %}
+            <div class="col-sm-4 col-lg-4">
+                <h2>{% trans "Featured Grid" %}</h2>
+                <h4><a href="{{ gotw.get_absolute_url }}">{{ gotw.title }}</a></h4>
+                <p>{{ gotw.description }}</p>
+                <p>
+                    <strong>{% trans "Packages" %}:</strong> {{ gotw.gridpackage_set.count }}
+                    <strong>{% trans "Features" %}:</strong> {{ gotw.feature_set.count }}
+                </p>
+            </div>
+          {% endif %}
+        <!-- end GOTW panel -->
     </div>
 </div>


### PR DESCRIPTION
**Description:**
This PR adds back the Grid of the week panel to the home page.

**_issue:_** https://github.com/djangopackages/djangopackages/issues/720