### PR TITLE
Avoid running the docker image building on forks

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -9,6 +9,7 @@ jobs:
   deploy:
     name: Build and Publish Production Docker Image
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'djangopackages'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Since the deploy workflow creates a commit on the main branch, the current configuration ends up causing the main branch of a fork to diverge from our main branch, which can hinder the contribution flow.

This pull-request makes the workflow deploy only run automatically in our organization, that is, it will be ignored in forks.