### PR TITLE
:bug: fixes query/display bug of Random 5 homepage packages

### DIFF
--- a/homepage/views.py
+++ b/homepage/views.py
@@ -109,9 +109,12 @@ def homepage(request, template_name="homepage.html"):
         categories.append(element)
 
     # get up to 5 random packages
-    package_count = Package.objects.count()
+    package_list = Package.objects.filter(
+        date_deprecated__isnull=True, deprecated_by__isnull=True
+    ).values_list("pk", flat=True)
+    package_count = len(package_list)
     random_packages = []
-    if package_count > 1:
+    if package_list.exists():
         package_ids = set()
 
         # Get 5 random keys
@@ -120,8 +123,8 @@ def homepage(request, template_name="homepage.html"):
                 range(1, package_count + 1)
             ),  # generate a list from 1 to package_count +1
             min(
-                package_count, 5
-            ),  # Get a sample of the smaller of 5 or the package count
+                package_count, 10
+            ),  # Get a sample of the smaller of 10 or the package count
         )
 
         # Get the random packages

--- a/templates/_homepage.html
+++ b/templates/_homepage.html
@@ -51,7 +51,7 @@
 
         <!-- start latest five packages -->
         <div class="col-sm-4 col-lg-4">
-            <h2>{% trans "Latest 5 Packages Added" %}</h2>
+            <h2>{% trans "Latest Five Packages Added" %}</h2>
 
             <div class="list-group">
                 {% for package in latest_packages %}
@@ -77,7 +77,7 @@
 
         <!-- start five random packages -->
         <div class="col-sm-4 col-lg-4">
-            <h2>{% trans "Random 5" %}</h2>
+            <h2>{% trans "Random Five Packages" %}</h2>
 
             <div class="list-group">
                 {% for package in random_packages %}


### PR DESCRIPTION
I noticed that the "Random 5" homepage view tends to show only 4 packages. This is because it's assumed that PKs line up with our total packages. We also show depreciated packages which this PR removes. 