### PR TITLE
update doc references from dev.yml to docker-compose.dev.yml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ simply run::
 
 To run tests, run::
 
-    docker-compose -f dev.yml run django python manage.py test
+    docker-compose -f docker-compose.dev.yml run django python manage.py test
 
 The Site
 --------

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -121,7 +121,7 @@ Run the tests!
 
 Before you submit a pull request, please run the entire Django Packages test suite via::
 
-    docker-compose -f dev.yml run django python manage.py test
+    docker-compose -f docker-compose.dev.yml run django python manage.py test
 
 The first thing the core committers will do is run this command. Any pull request that fails this test suite will be **rejected**.
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -50,7 +50,7 @@ The effort to support databases besides PostGreSQL was hampered for long time, a
 
 So we use a **Mock** system of creating sample data in our tests and for running a development version of the site. To create some development data, just run::
 
-    docker-compose -f dev.yml run django python manage.py load_dev_data
+    docker-compose -f docker-compose.dev.yml run django python manage.py load_dev_data
 
 Unsupported Repo Hosting Services
 =================================

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -40,7 +40,7 @@ Now build the project using docker-compose:
 
 .. code-block:: bash
 
-    docker-compose -f dev.yml build
+    docker-compose -f docker-compose.dev.yml build
 
 Run the Project
 ---------------
@@ -49,7 +49,7 @@ To start the project, run:
 
 .. code-block:: bash
 
-    docker-compose -f dev.yml up
+    docker-compose -f docker-compose.dev.yml up
 
 Then point your browser to http://localhost:8000 and start hacking!
 
@@ -62,7 +62,7 @@ Create a Django superuser for yourself, replacing joe with your username/email:
 
 .. code-block:: bash
 
-    docker-compose -f dev.yml run django python manage.py createsuperuser --username=joe --email=joe@example.com
+    docker-compose -f docker-compose.dev.yml run django python manage.py createsuperuser --username=joe --email=joe@example.com
 
 And then login into the admin interface (/admin/) and create a profile for your user filling all the fields with any data.
 

--- a/docs/management_commands.rst
+++ b/docs/management_commands.rst
@@ -7,7 +7,7 @@ package_updater
 
 You can update all the packages with the following command::
 
-    docker-compose -f dev.yml run django python manage.py package_updater
+    docker-compose -f docker-compose.dev.yml run django python manage.py package_updater
 
 Warning: This can take a long, long time.
 
@@ -16,7 +16,7 @@ searchv2_build
 
 To populate the search engine, run::
 
-    docker-compose -f dev.yml run django python manage.py searchv2_build
+    docker-compose -f docker-compose.dev.yml run django python manage.py searchv2_build
 
 
 pypi_updater
@@ -24,5 +24,4 @@ pypi_updater
 
 To update packages with the latest data on PyPi, run::
 
-    docker-compose -f dev.yml run django python manage.py pypi_updater
-
+    docker-compose -f docker-compose.dev.yml run django python manage.py pypi_updater

--- a/docs/testing_instructions.rst
+++ b/docs/testing_instructions.rst
@@ -8,8 +8,8 @@ Running the test suite
 
 To run all of the Django Packages tests::
 
-    docker-compose -f dev.yml run django python manage.py test
+    docker-compose -f docker-compose.dev.yml run django python manage.py test
 
 To run tests for a particular Django Packages app, for example the feeds app::
 
-    docker-compose -f dev.yml run django python manage.py test feeds
+    docker-compose -f docker-compose.dev.yml run django python manage.py test feeds


### PR DESCRIPTION
Updated commands in documentation files (*.rst) where the command referred to "dev.yml", changing them to "docker-compose.dev.yml".

There were two places referring to this that I didn't change:

* One was in `CHANGELOG.md`, and refers to the name of an issue rather than syntax of a currently used command.
* One was in `.devcontainer/devcontainer.json`, and that seems to be a VS Code config file, that I'm leery of messing with because I'm not currently using VS Code and don't know what this might affect.