### PR TITLE
:gear: partially use a pytest settings fixture

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,12 +2,22 @@ import logging
 import datetime
 import pytest
 
+from django.test.utils import override_settings
+
 
 pytest_plugins = [
     "grid.tests.fixtures",
     "homepage.tests.fixtures",
     "package.tests.fixtures",
 ]
+
+
+TEST_SETTINGS = {
+    "CELERY_TASK_ALWAYS_EAGER": True,
+    "EMAIL_BACKEND": "django.core.mail.backends.locmem.EmailBackend",
+    "LOGGING_CONFIG": None,
+    "PASSWORD_HASHERS": ["django.contrib.auth.hashers.MD5PasswordHasher"],
+}
 
 
 def pytest_configure(config):
@@ -18,6 +28,12 @@ def pytest_configure(config):
 def set_time(time_machine):
     time_machine.move_to(datetime.datetime(2022, 2, 22, 2, 22))
     yield
+
+
+@pytest.fixture(autouse=True, scope="session")
+def use_test_settings():
+    with override_settings(**TEST_SETTINGS):
+        yield
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Small update to set up moving settings into a pytest fixture. (also shaves off some testing time.)