### PR TITLE
:rocket: Homepage Cache

### DIFF
--- a/homepage/tests/test_views.py
+++ b/homepage/tests/test_views.py
@@ -36,6 +36,7 @@
 #     assert response.status_code == 200
 #     assertTemplateUsed(response, "homepage.html")
 
+
 def test_homepage(db, tp, django_assert_num_queries):
     url = tp.reverse("home")
     with django_assert_num_queries(10):

--- a/templates/_homepage.html
+++ b/templates/_homepage.html
@@ -12,7 +12,7 @@
                     <p>{{ category.description }}</p>
                     <a href="{% url 'category' category.slug %}" class="btn btn-primary">Show {{ category.title_plural }} ({{ category.package_count|intcomma }})</a>
                 </div>
-                {% endif %}
+            {% endif %}
         {% endfor %}
         <!-- end Categories panel -->
     </div>


### PR DESCRIPTION
The goal here is to cache a few common homepage bits that take longer than we'd like to load. 