### PR TITLE
:gear: set DISABLE_SERVER_SIDE_CURSORS to True

### DIFF
--- a/settings/docker.py
+++ b/settings/docker.py
@@ -141,6 +141,7 @@ structlog.configure(
 # ------------------------------------------------------------------------------
 # Raises ImproperlyConfigured exception if DATABASE_URL not in os.environ
 DATABASES["default"] = env.db("DATABASE_URL")
+DATABASES["default"]["DISABLE_SERVER_SIDE_CURSORS"] = True
 ########## END DATABASE CONFIGURATION
 
 ########## django-secure


### PR DESCRIPTION
We get tons of `InvalidCursorName` sentry errors with our connection pooling so changing this up to see if they go away:

https://docs.djangoproject.com/en/4.1/ref/databases/#transaction-pooling-and-server-side-cursors