### PR TITLE
Add Option to Sort Grid Packages

### DIFF
--- a/grid/forms.py
+++ b/grid/forms.py
@@ -1,7 +1,8 @@
 """Forms for the :mod:`grid` app
 """
 
-from django.forms import ModelForm
+from django.forms import BooleanField, ChoiceField, Form, ModelForm
+from django.utils.translation import gettext_lazy as _
 
 from grid.models import Element, Feature, Grid, GridPackage
 
@@ -53,3 +54,27 @@ class GridPackageForm(ModelForm):
     class Meta:
         model = GridPackage
         fields = ["package"]
+
+
+class GridPackageFilterForm(Form):
+    """Filter and sort form for the grid package list"""
+
+    SCORE = "score"
+    COMMIT_DATE = "commit_date"
+    WATCHERS = "watchers"
+    DOWNLOADS = "downloads"
+    FORKS = "forks"
+
+    SORT_CHOICES = (
+        (SCORE, _("Score")),
+        (COMMIT_DATE, _("Last Commit Date")),
+        (WATCHERS, _("Watchers")),
+        (DOWNLOADS, _("Downloads")),
+        (FORKS, _("Forks")),
+    )
+
+    python3 = BooleanField(required=False, label=_("Python 3"))
+    stable = BooleanField(required=False)
+    sort = ChoiceField(
+        choices=SORT_CHOICES, initial=SCORE, required=False, label=_("Sort by")
+    )

--- a/static/css/grid.css
+++ b/static/css/grid.css
@@ -37,18 +37,3 @@ td.package-name {
     text-align: center;
     font-weight: bold;
 }
-.grid-filters {
-    margin-bottom: 20px;
-}
-.grid-filter {
-    display: flex;
-    align-items: center;
-    margin-bottom: 5px;
-}
-.grid-filter__checkbox {
-    margin: 0 !important;
-}
-.grid-filter__label {
-    margin: 0 0 0 5px;
-    font-size: 12px;
-}

--- a/templates/grid/grid_detail.html
+++ b/templates/grid/grid_detail.html
@@ -1,6 +1,7 @@
 {% extends "grid/base.html" %}
 
 {% load cache %}
+{% load crispy_forms_tags %}
 {% load grid_tags %}
 {% load humanize %}
 {% load i18n %}
@@ -29,7 +30,7 @@
             </h2>
         </div>
     </div>
-    {% cache 300 html_grid_detail_outer grid.pk filters %}
+    {% cache 300 html_grid_detail_outer grid.pk request.GET.urlencode %}
         <div class="row">
             <div class="col-lg-{% if features %}3{% else %}6{% endif %}">
                 <p>
@@ -98,22 +99,15 @@
             {% endif %}
         </div>
 
-        <div class="row grid-filters">
+        <div class="row">
             <div class="col-lg-12">
                 <h3>{% trans "Filter results" %}</h3>
             </div>
-            <div class="col-lg-12">
-                <div class="grid-filter">
-                    <input class="grid-filter__checkbox" type="checkbox" value="python3" id="python3-filter">
-                    <label class="grid-filter__label" for="python3-filter">Python 3</label>
+            <form method="get" action="{{ request.path }}" id="filterForm">
+                <div class="col-lg-2 col-md-3 col-sm-4">
+                    {{ filter_form|crispy }}
                 </div>
-            </div>
-            <div class="col-lg-12">
-                <div class="grid-filter">
-                    <input class="grid-filter__checkbox" type="checkbox" value="stable" id="stable-filter">
-                    <label class="grid-filter__label" for="stable-filter">Stable</label>
-                </div>
-            </div>
+            </form>
         </div>
 
         <!-- Grid is not inside of a Bootstrap grid row because it needs max width. -->
@@ -368,58 +362,9 @@
             $(window).scroll(scrollFixed);
             resizeFixed();
 
-            // Parse URL query strings into an array
-            function getQueryStringParams() {
-                const params = [];
-                const queryStringStart = window.location.href.indexOf("?");
-                const rawParams = queryStringStart > -1
-                ? window.location.href.slice(queryStringStart + 1).split("&")
-                : [];
-                for(let i = 0; i < rawParams.length; i++) {
-                    const param = rawParams[i].split("=");
-                    params.push([param[0], param[1]]);
-                }
-                return params;
-            }
-
-            // handle filtering
-            $(".grid-filter__checkbox").each(function() {
-                const qs = getQueryStringParams()
-
-                // tick filters already present on pageload
-                for(let i = 0; i < qs.length; i++) {
-                    if (qs[i][0] === this.value && qs[i][1] === "1") {
-                        $(this).prop("checked", true);
-                    }
-                }
-                // handle redirect when checking/unchecking filters
-                $(this).click(function() {
-                    const qsArr = [];
-                    if ($(this).is(":checked")) {
-                        let found = false;
-                        for(let i = 0; i < qs.length; i++) {
-                            if (qs[i][0] === this.value) {
-                                found = true;
-                                qsArr.push(this.value + "=1");
-                            } else {
-                                qsArr.push(qs[i][0] + "=" + qs[i][1]);
-                            }
-                        }
-                        if (!found) {
-                            qsArr.push(this.value + "=1");
-                        }
-                    } else {
-                        for(let i = 0; i < qs.length; i++) {
-                            if (qs[i][0] !== this.value) {
-                                qsArr.push(qs[i][0] + "=" + qs[i][1]);
-                            }
-                        }
-                    }
-                    const qsStr = qsArr.length ? "?" + qsArr.join("&") : "";
-                    $(location).attr('href', window.location.pathname + qsStr);
-                });
+            $("#filterForm").on("input", function() {
+                this.submit();
             });
-
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
#### Details

This Pull Request:
- Adds option to sort Grid Packages by `downloads`, `watchers`, `forks`, `last_commit_date` and `score` (default)
- Refactors the filters to use Django Forms
- Removes CSS and JavaScript that are not required anymore

#### Screenshot of the filters

![Screenshot](https://user-images.githubusercontent.com/24854406/197487437-a74f4eea-56c5-4aea-a26e-dd45d1e1d249.png)


closes https://github.com/djangopackages/djangopackages/issues/199