### PR TITLE
Fix Global Search

### DIFF
--- a/static/angular/controllers.js
+++ b/static/angular/controllers.js
@@ -17,11 +17,9 @@ function SearchCtrl($scope, $http) {
     } else {
         $scope.items = [];
     };
-    console.log($scope);
   };
 
   $scope.get_python3_packages = function(url){
-    console.log("what")
     $http.get(url).success(function(data) {
         $scope.python3_packages = data.results;
     });

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,6 +1,5 @@
 {% load i18n profile_tags static %}
 {% load package_tags %}
-{% load emojificate %}
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}" xml:lang="{{ LANGUAGE_CODE }}" lang="{{ LANGUAGE_CODE }}" {% block angular_header %}ng-app{% endblock angular_header %}>
     <head>
@@ -138,7 +137,7 @@
                   </td>
                   <td>
                     <strong ng-if="item.item_type=='grid'">Grid:</strong>
-                    {{ item.description | emojify| emojificate  }}
+                    {{ item.description }}
                   </td>
 
                   <td ng-if="item.item_type=='package'">


### PR DESCRIPTION
AngularJS raises an exception when `emojificate` templatetag is used inside search results `ng-repeat` Directive.

**Console output:**
```console
Error: Unknown provider: emojifyFilterProvider <- emojifyFilter

at angular.min.js:29:439
at Object.c [as get] (angular.min.js:27:142)
at angular.min.js:30:21
at Object.c [as get] (angular.min.js:27:142)
at angular.min.js:109:235
at u (angular.min.js:70:141)
at w (angular.min.js:75:72)
at l (angular.min.js:69:507)
at Rc (angular.min.js:75:170)
at angular.min.js:78:426
```

closes https://github.com/djangopackages/djangopackages/issues/862