### PR TITLE
✨ Add widont support

### DIFF
--- a/core/templatetags/typogrify_tags.py
+++ b/core/templatetags/typogrify_tags.py
@@ -1,0 +1,150 @@
+"""
+Modified version from: https://github.com/chrisdrackett/django-typogrify
+
+Typogrify:
+==========
+
+Copyright (c) 2007, Christian Metts
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of the author nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Fuzzy Date / Typogrify Updates:
+===============================
+
+Copyright (c) 2010, Chris Drackett
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of the author nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+titlecase.py
+============
+
+Original Perl version by: John Gruber http://daringfireball.net/ 10 May 2008
+Python version by Stuart Colville http://muffinresearch.co.uk
+License: http://www.opensource.org/licenses/mit-license.php
+
+"""
+import re
+
+from django import template
+from django.utils.html import conditional_escape
+from django.utils.safestring import mark_safe
+
+
+register = template.Library()
+
+
+def smart_filter(fn):
+    """
+    Escapes filter's content based on template autoescape mode and marks output as safe
+    """
+
+    def wrapper(text, autoescape=None):
+        if autoescape:
+            esc = conditional_escape
+        else:
+            esc = lambda x: x
+
+        return mark_safe(fn(esc(text)))
+
+    wrapper.needs_autoescape = True
+
+    register.filter(fn.__name__, wrapper)
+    return wrapper
+
+
+@smart_filter
+def widont(text):
+    """Replaces the space between the last two words in a string with ``&nbsp;``
+    Works in these block tags ``(h1-h6, p, li, dd, dt)`` and also accounts for
+    potential closing inline elements ``a, em, strong, span, b, i``
+    >>> widont('A very simple test')
+    u'A very simple&nbsp;test'
+    Single word items shouldn't be changed
+    >>> widont('Test')
+    u'Test'
+    >>> widont(' Test')
+    u' Test'
+    >>> widont('<ul><li>Test</p></li><ul>')
+    u'<ul><li>Test</p></li><ul>'
+    >>> widont('<ul><li> Test</p></li><ul>')
+    u'<ul><li> Test</p></li><ul>'
+    >>> widont('<p>In a couple of paragraphs</p><p>paragraph two</p>')
+    u'<p>In a couple of&nbsp;paragraphs</p><p>paragraph&nbsp;two</p>'
+    >>> widont('<h1><a href="#">In a link inside a heading</i> </a></h1>')
+    u'<h1><a href="#">In a link inside a&nbsp;heading</i> </a></h1>'
+    >>> widont('<h1><a href="#">In a link</a> followed by other text</h1>')
+    u'<h1><a href="#">In a link</a> followed by other&nbsp;text</h1>'
+    Empty HTMLs shouldn't error
+    >>> widont('<h1><a href="#"></a></h1>')
+    u'<h1><a href="#"></a></h1>'
+    >>> widont('<div>Divs get no love!</div>')
+    u'<div>Divs get no love!</div>'
+    >>> widont('<pre>Neither do PREs</pre>')
+    u'<pre>Neither do PREs</pre>'
+    >>> widont('<div><p>But divs with paragraphs do!</p></div>')
+    u'<div><p>But divs with paragraphs&nbsp;do!</p></div>'
+    """
+
+    widont_finder = re.compile(
+        r"""((?:</?(?:a|em|span|strong|i|b)[^>]*>)|[^<>\s]) # must be proceeded by an approved inline opening or closing tag or a nontag/nonspace
+                                   \s+                                             # the space to replace
+                                   ([^<>\s]+                                       # must be flollowed by non-tag non-space characters
+                                   \s*                                             # optional white space!
+                                   (</(a|em|span|strong|i|b)>\s*)*                 # optional closing inline tags with optional white space after each
+                                   ((</(p|h[1-6]|li|dt|dd)>)|$))                   # end with a closing p, h1-6, li or the end of the string
+                                   """,
+        re.VERBOSE,
+    )
+
+    output = widont_finder.sub(r"\1&nbsp;\2", text)
+    return output

--- a/templates/_homepage.html
+++ b/templates/_homepage.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load package_tags %}
 {% load emojificate %}
+{% load typogrify_tags %}
 
 <div class="container">
     <div class="row">
@@ -10,7 +11,7 @@
             {% if category.package_count %}
                 <div class="categories col-sm-3 text-center">
                     <h2 class="panel-title">{{ category.title_plural }} </h2>
-                    <p>{{ category.description }}</p>
+                    <p>{{ category.description|widont }}</p>
                     <a href="{% url 'category' category.slug %}" class="btn btn-primary">Show {{ category.title_plural }} ({{ category.package_count|intcomma }})</a>
                 </div>
             {% endif %}
@@ -35,9 +36,9 @@
                         <p class="list-group-item-text">
                             {% with version.package.repo_description|truncatewords:25 as short %}
                                 {% if version.package.repo_description|length > short|length %}
-                                    {{ short|slice:"-3" }}...
+                                    {{ short|slice:"-3"|widont }}...
                                 {% else %}
-                                    {{ short }}
+                                    {{ short|widont }}
                                 {% endif %}
                             {% endwith %}
                         </p>

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -11,8 +11,7 @@
         <div class="container text-center">
             <div class="row">
                 <div class="col-sm-10 col-sm-offset-1">
-                    <h1>{{ SITE_TITLE }} is a directory of reusable apps, sites, tools, and more for your {{ FRAMEWORK_TITLE }}
-                        projects.</h1>
+                    <h1>{{ SITE_TITLE }} is a directory of reusable apps, sites, tools, and more for your {{ FRAMEWORK_TITLE }}&nbsp;projects.</h1>
                     <p><a class="btn btn-primary btn-lg" href="{% url 'add_package' %}" role="button">{% trans "Add Package" %}</a>
                         <a class="btn btn-primary btn-lg" href="{% url 'add_grid' %}" role="button">{% trans "Add Grid" %}</a></p>
                 </div>


### PR DESCRIPTION
Adds "widont" support to avoid hanging words on the homepage, which is where it annoys me the most. 

The `django-typogrify` is currently not supported for Django 4.0, so I pulled in just what we needed. It has some other useful tags in it though too. 