### PR TITLE
Add Sidebar and Logo for Documentation Page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,7 +135,7 @@ html_theme_options = {
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-# html_logo = None
+html_logo = "../static/img/logo_squares.png"
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
@@ -156,7 +156,9 @@ html_static_path = ["_static"]
 # html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-# html_sidebars = {}
+html_sidebars = {
+    "**": ["logo-text.html", "globaltoc.html", "localtoc.html", "searchbox.html"]
+}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -24,7 +24,7 @@ If you have git installed, you now clone your git repo using the following comma
 Install Django Packages Locally
 -------------------------------
 
-Follow our detailed :doc:`installation` instructions. Please record any difficulties you have and share them with the Django Packages community via our `issue tracker`_.
+Follow our detailed :doc:`installation <install>` instructions. Please record any difficulties you have and share them with the Django Packages community via our `issue tracker`_.
 
 Issues!
 =======

--- a/docs/deployment/docker.rst
+++ b/docs/deployment/docker.rst
@@ -17,7 +17,7 @@ restarded, the stack won't start automatically.
 The current strategy is:
 
  - Use a virtual machine with a well patched OS (debian, ubuntu, RHEL), djangopackages.org is using
- ubuntu 14.04
+   ubuntu 14.04
  - Install docker, docker-compose, git and supervisord
  - Clone the code on the server
  - Let supervisord run it

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,11 +29,8 @@ Contents:
    deployment/index
    troubleshooting
    faq
-   opencomparison_settings
    testing_instructions
    management_commands
-   pypi_issues
-   contributors
    contributing
    repo_handlers
    apiv3_docs


### PR DESCRIPTION
## Details
- Adds Logo to Documentation
- Adds Sidebar to Documetation
- Fixes Bullet List Warning (`Bullet list ends without a blank line`)
- Removes nonexistent references from `toctree` (`toctree contains reference to nonexisting document`)
- Fixes `:doc:` reference issue. (`unknown document: 'installation'`)

### Before:
![Before](https://user-images.githubusercontent.com/24854406/201524974-04d61a6d-251e-4441-94a0-9fa19fd2ad25.png)


### After:
![After](https://user-images.githubusercontent.com/24854406/201524979-c57f9f2c-b12a-49f0-9d1a-0b0c73b7b2b7.png)
