### PR TITLE
:tractor: Updates docs domain

### DIFF
--- a/.github/CONTRIBUTORS-template.md
+++ b/.github/CONTRIBUTORS-template.md
@@ -24,7 +24,7 @@ accept and merge pull requests.
 
 For Django Dash 2010, @pydanny and @audreyr created Django Packages.
 
-They are joined by a host of core developers and contributors. See https://djangopackages.readthedocs.io/en/latest/contributors.html
+They are joined by a host of core developers and contributors. See https://docs.djangopackages.org/en/latest/contributors.html
 
 ## Other Contributors
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,7 +15,7 @@ accept and merge pull requests.
 
 For Django Dash 2010, @pydanny and @audreyr created Django Packages.
 
-They are joined by a host of core developers and contributors. See https://djangopackages.readthedocs.io/en/latest/contributors.html
+They are joined by a host of core developers and contributors. See https://docs.djangopackages.org/en/latest/contributors.html
 
 ## Other Contributors
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Django Packages helps you easily identify and compare good apps, frameworks, plu
 
 ## Badges
 
-[![image](https://github.com/djangopackages/djangopackages/actions/workflows/actions.yml/badge.svg)](https://github.com/djangopackages/djangopackages/actions/workflows/actions.yml) [![Documentation Status](https://readthedocs.org/projects/djangopackages/badge/?version=latest)](https://djangopackages.readthedocs.io/en/latest/?badge=latest) [![Updates](https://pyup.io/repos/github/djangopackages/djangopackages/shield.svg)](https://pyup.io/repos/github/djangopackages/djangopackages/)
+[![image](https://github.com/djangopackages/djangopackages/actions/workflows/actions.yml/badge.svg)](https://github.com/djangopackages/djangopackages/actions/workflows/actions.yml) [![Documentation Status](https://readthedocs.org/projects/djangopackages/badge/?version=latest)](https://docs.djangopackages.org/en/latest/?badge=latest) [![Updates](https://pyup.io/repos/github/djangopackages/djangopackages/shield.svg)](https://pyup.io/repos/github/djangopackages/djangopackages/)
 
 ## Features
 
@@ -25,7 +25,7 @@ Django Packages helps you easily identify and compare good apps, frameworks, plu
 
 ## Quickstart
 
-For detailed installation instructions, consult the [docs](https://djangopackages.readthedocs.io/en/latest/install.html).
+For detailed installation instructions, consult the [docs](https://docs.djangopackages.org/en/latest/install.html).
 
 To download, install and start the local server for development, simply run:
 
@@ -59,7 +59,7 @@ https://djangopackages.org
 
 ## The Documentation
 
-The documentation is hosted at http://djangopackages.readthedocs.io/en/latest
+The documentation is hosted at https://docs.djangopackages.org/en/latest
 
 ## License
 
@@ -69,4 +69,4 @@ The code is open-source and licensed under the MIT license.
 
 For Django Dash 2010, [@pydanny](https://github.com/pydanny/) and [@audreyr](https://github.com/audreyr/) created [Django Packages](https://www.djangopackages.org/).
 
-They are joined by a host of core developers and contributors. See https://djangopackages.readthedocs.io/en/latest/contributors.html
+They are joined by a host of core developers and contributors. See https://docs.djangopackages.org/en/latest/contributors.html

--- a/core/apiv1.py
+++ b/core/apiv1.py
@@ -5,7 +5,7 @@ Please switch to APIv3:
 
 <ul>
     <li><a href="https://www.djangopackages.org/api/v3/">APIv3 Endpoint</a></li>
-    <li><a href="https://djangopackages.readthedocs.io/en/latest/apiv3_docs.html">APIv3 Documentation</a></li>
+    <li><a href="https://docs.djangopackages.org/en/latest/apiv3_docs.html">APIv3 Documentation</a></li>
     <li><a href="http://www.pydanny.com/phasing-out-django-packages-apiv1-apiv2.html">APIv1 end-of-life notification</a></li>
 </ul>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -174,9 +174,9 @@
 
                     <a href="{% url 'terms' %}">{% trans "Terms" %}</a>
 
-                    <a href="https://djangopackages.readthedocs.io/en/latest/contributing.html">{% trans "Contribute" %}</a>
+                    <a href="https://docs.djangopackages.org/en/latest/contributing.html">{% trans "Contribute" %}</a>
 
-                    <a href="https://djangopackages.readthedocs.io/en/latest/apiv3_docs.html">{% trans "API" %}</a>
+                    <a href="https://docs.djangopackages.org/en/latest/apiv3_docs.html">{% trans "API" %}</a>
 
                     <a href="{% url 'syndication' %}">{% trans "RSS / Atom" %}</a>
 

--- a/templates/pages/faq.html
+++ b/templates/pages/faq.html
@@ -67,7 +67,7 @@
                 <h3>How can I contribute?</h3>
 
                 <p>This is an open source project, and we appreciate
-                    <a href="https://djangopackages.readthedocs.io/en/latest/contributing.html">all sorts of contributions</a>.
+                    <a href="https://docs.djangopackages.org/en/latest/contributing.html">all sorts of contributions</a>.
                 </p>
 
             </div>


### PR DESCRIPTION
This moves our default docs home/location to https://docs.djangopackages.org/en/latest/ 