### PR TITLE
Enable `django-debug-toolbar`

### DIFF
--- a/settings/base.py
+++ b/settings/base.py
@@ -1,5 +1,5 @@
 # Django settings
-
+import sys
 from pathlib import Path
 
 import environ
@@ -11,6 +11,7 @@ PROJECT_ROOT = Path(__file__).parent.parent
 
 DEBUG = env.bool("DJANGO_DEBUG", True)
 TEMPLATE_DEBUG = env.bool("TEMPLATE_DEBUG", True)
+TEST_MODE = "pytest" in sys.modules
 
 INTERNAL_IPS = [
     "127.0.0.1",
@@ -282,9 +283,9 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 WSGI_APPLICATION = "wsgi.application"
 
-if DEBUG:
+if DEBUG and not TEST_MODE:
     INSTALLED_APPS += ["debug_toolbar"]
-    # MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
+    MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
     DEBUG_TOOLBAR_CONFIG = {
         "INTERCEPT_REDIRECTS": False,
         "SHOW_TOOLBAR_CALLBACK": lambda _request: DEBUG,

--- a/urls.py
+++ b/urls.py
@@ -86,7 +86,7 @@ urlpatterns = [
     # url(r'^api/v1/', include('core.apiv1', namespace="apitest")),
 ]
 
-if settings.DEBUG:
+if settings.DEBUG and not settings.TEST_MODE:
     import debug_toolbar
 
     urlpatterns.append(path("__debug__/", include(debug_toolbar.urls)))


### PR DESCRIPTION
This PR:

1. Enables `django-debug-toolbar` for development
2. Fixes Test Failure when `django-debug-toolbar` is enabled.

Alternative:

- Using [pytest-is-running](https://github.com/adamchainz/pytest-is-running) package.

Discussion:
- https://github.com/pytest-dev/pytest/issues/9502