### PR TITLE
Update VSCode Dev Containers

### DIFF
--- a/.devcontainer/create_dot_env.sh
+++ b/.devcontainer/create_dot_env.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+if [ ! -f ".env.local" ]; then
+    echo ".env.local created"
+    cp .env.local.example .env.local
+fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,47 +1,75 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/python-3
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose
 {
-    "name": "Existing Docker Compose (Extend)",
-    "dockerComposeFile": [
-        "docker-compose.yml"
-    ],
-    // Add the IDs of extensions you want installed when the container is created.
-    "extensions": [
-		"eamodio.gitlens",
-		"editorconfig.editorconfig",
-		"ms-azuretools.vscode-docker",
-		"ms-python.python",
-		"ms-python.vscode-pylance",
-		"redhat.vscode-yaml",
-		"ms-vscode-remote.remote-containers"
+	"name": "Existing Docker Compose (Extend)",
+	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
+	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+	"dockerComposeFile": [
+		"../docker-compose.yml",
+		"docker-compose.yml"
 	],
-    "mounts": [
-        "source=vscode-server-extensions,target=/root/.vscode-server/extensions,type=volume",
-        "source=vscode-server-insiders-extensions,target=/root/.vscode-server-insiders/extensions,type=volume",
-    ],
-    // mentioned in https://github.com/microsoft/vscode-remote-release/issues/5317
-    "updateRemoteUserUID": false,
-    // "runServices": ["django"],
-    "service": "django",
-    "settings": {
-        "files.exclude":{
-            "**/.DS_Store": true,
-            "**/.git": true,
-            "**/.hg": true,
-            "**/.svn": true,
-            "**/CVS": true,
-            "**/data": true,
-            "**/Thumbs.db": true,
-        },
-        "terminal.integrated.shell.linux": "/bin/bash",
-        "python.defaultInterpreterPath": "/usr/local/bin/python"
-    },
-    // "workspaceMount": "source=${localWorkspaceFolder}/myRepo,target=/workspaces,type=bind,consistency=delegated",
-    "workspaceFolder": "/workspace/"
-    // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    // "forwardPorts": [],
-    // Use 'postCreateCommand' to run commands after the container is created.
-    // "postCreateCommand": "pip3 install --user -r requirements.txt",
-    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-    // "remoteUser": "vscode"
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"eamodio.gitlens",
+				"editorconfig.editorconfig",
+				"ms-azuretools.vscode-docker",
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"redhat.vscode-yaml",
+				"ms-vscode-remote.remote-containers"
+			],
+			"settings": {
+				// Configure glob patterns for excluding files and folders.
+				// For example, the File Explorer decides which files and folders to show or hide based on this setting.
+				"files.exclude": {
+					"**/.DS_Store": true,
+					"**/.git": true,
+					"**/.hg": true,
+					"**/.svn": true,
+					"**/CVS": true,
+					"**/data": true,
+					"**/Thumbs.db": true
+				},
+				// Configure paths or glob patterns to exclude from file watching.
+				"files.watcherExclude": {
+					"**/.DS_Store": true,
+					"**/.git": true,
+					"**/.hg": true,
+					"**/.svn": true,
+					"**/CVS": true,
+					"**/data": true,
+					"**/Thumbs.db": true,
+					"**/design": true
+				},
+				// The default profile used on Linux.
+				"terminal.integrated.defaultProfile.linux": "bash",
+				"python.defaultInterpreterPath": "/usr/local/bin/python"
+			}
+		}
+	},
+	// mentioned in https://github.com/microsoft/vscode-remote-release/issues/5317
+	"updateRemoteUserUID": false,
+	// The 'service' property is the name of the service for the container that VS Code should
+	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+	"service": "django",
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		8000
+	]
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	// "shutdownAction": "none",
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
 		"../docker-compose.yml",
 		"docker-compose.yml"
 	],
+	"initializeCommand": ".devcontainer/create_dot_env.sh",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,27 +1,24 @@
-version: '3'
-
+version: '3.6'
 services:
+  # Update this to the name of the service you want to work with in your docker-compose.yml file
   django:
+    # Uncomment if you want to override the service's Dockerfile to one in the .devcontainer
+    # folder. Note that the path of the Dockerfile and context is relative to the *primary*
+    # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
+    # array). The sample below assumes your primary file is in the root of your project.
+    #
+    # build:
+    #   context: .
+    #   dockerfile: .devcontainer/Dockerfile
 
     volumes:
-      - .:/workspace:cached
-      - /var/run/docker.sock:/var/run/docker.sock
-      - vscode-server-extensions:/root/.vscode-server/extensions
-      - vscode-server-insiders-extensions:/root/.vscode-server-insiders/extensions
+      # Update this to wherever you want VS Code to mount the folder of your project
+      - ..:/workspaces:cached
+    # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
+    # cap_add:
+    #   - SYS_PTRACE
+    # security_opt:
+    #   - seccomp:unconfined
 
     # Overrides default command so things don't shut down after the process ends.
-    command: sleep infinity
-    # command: /bin/sh -c "while sleep 1000; do :; done"
-
-    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
-    # network_mode: service:db
-
-    # Uncomment the next line to use a non-root user for all processes.
-    # user: vscode
-
-    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
-    # (Adding the "ports" property to this file will not forward from a Codespace.)
-
-volumes:
-  vscode-server-extensions:
-  vscode-server-insiders-extensions:
+    # command: sleep infinity

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,20 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Python: MkDocs",
+      "type": "python",
+      "request": "launch",
+      "module": "mkdocs",
+      "args": [
+        "serve",
+        "-f",
+        "${workspaceFolder}/docs/mkdocs.yml",
+        "--dev-addr",
+        "0.0.0.0:4000"
+      ],
+      "justMyCode": false
+    },
+    {
       "name": "Python: Django",
       "type": "python",
       "request": "launch",
@@ -18,15 +32,15 @@
       "justMyCode": false
     },
     {
-      "name": "pytest test",
+      "name": "Python: PyTest",
       "type": "python",
       "request": "launch",
       "console": "integratedTerminal",
       "python": "${command:python.interpreterPath}",
       "module": "pytest",
       "args": [
-        "-c",
-        "${workspaceFolder}/pytest.ini",
+        // "-c",
+        // "${workspaceFolder}/pytest.ini",
         "--reuse-db",
         // "-v",
         // "-x",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "esbonio.sphinx.confDir": ""
-}


### PR DESCRIPTION
**This PR**

- Adds Launch Configuration for `mkdocs` Documentation
- Fixes Launch Configuration for `pytest`
- Removes Deprecated/Removed Options from Dev Containers Configuration file.

**PyCharm Support**

PyCharm does not have support for dev containers. Discussion: https://youtrack.jetbrains.com/issue/IDEA-202267

**Tested in**

- Linux (Ubuntu)
- GitHub Codespaces

closes https://github.com/djangopackages/djangopackages/issues/942