### PR TITLE
Fix broken links to documentation

### DIFF
--- a/.github/CONTRIBUTORS-template.md
+++ b/.github/CONTRIBUTORS-template.md
@@ -24,7 +24,7 @@ accept and merge pull requests.
 
 For Django Dash 2010, @pydanny and @audreyr created Django Packages.
 
-They are joined by a host of core developers and contributors. See https://docs.djangopackages.org/en/latest/contributors
+They are joined by a host of core developers and contributors. See https://github.com/djangopackages/djangopackages/blob/main/CONTRIBUTORS.md
 
 ## Other Contributors
 

--- a/.github/CONTRIBUTORS-template.md
+++ b/.github/CONTRIBUTORS-template.md
@@ -24,7 +24,7 @@ accept and merge pull requests.
 
 For Django Dash 2010, @pydanny and @audreyr created Django Packages.
 
-They are joined by a host of core developers and contributors. See https://docs.djangopackages.org/en/latest/contributors.html
+They are joined by a host of core developers and contributors. See https://docs.djangopackages.org/en/latest/contributors
 
 ## Other Contributors
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,7 +15,7 @@ accept and merge pull requests.
 
 For Django Dash 2010, @pydanny and @audreyr created Django Packages.
 
-They are joined by a host of core developers and contributors. See https://docs.djangopackages.org/en/latest/contributors
+They are joined by a host of core developers and contributors. See https://github.com/djangopackages/djangopackages/blob/main/CONTRIBUTORS.md
 
 ## Other Contributors
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,7 +15,7 @@ accept and merge pull requests.
 
 For Django Dash 2010, @pydanny and @audreyr created Django Packages.
 
-They are joined by a host of core developers and contributors. See https://docs.djangopackages.org/en/latest/contributors.html
+They are joined by a host of core developers and contributors. See https://docs.djangopackages.org/en/latest/contributors
 
 ## Other Contributors
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Django Packages helps you easily identify and compare good apps, frameworks, plu
 
 ## Quickstart
 
-For detailed installation instructions, consult the [docs](https://docs.djangopackages.org/en/latest/install.html).
+For detailed installation instructions, consult the [docs](https://docs.djangopackages.org/en/latest/install).
 
 To download, install and start the local server for development, simply run:
 

--- a/core/apiv1.py
+++ b/core/apiv1.py
@@ -5,7 +5,7 @@ Please switch to APIv3:
 
 <ul>
     <li><a href="https://www.djangopackages.org/api/v3/">APIv3 Endpoint</a></li>
-    <li><a href="https://docs.djangopackages.org/en/latest/apiv3_docs.html">APIv3 Documentation</a></li>
+    <li><a href="https://docs.djangopackages.org/en/latest/apiv3_docs">APIv3 Documentation</a></li>
     <li><a href="http://www.pydanny.com/phasing-out-django-packages-apiv1-apiv2.html">APIv1 end-of-life notification</a></li>
 </ul>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -155,7 +155,7 @@
         </div>
         <div class="container pre-pre-footer">
             <div class="row">
-                <div class="col-sm-12 text-center">
+                <div class="text-center col-sm-12">
 
                     Projects listed on Djangopackages are third-party packages. They are not vetted nor endorsed by the Django Software Foundation. Use them at your own risk.
 
@@ -165,7 +165,7 @@
         </div>
         <div class="container pre-footer">
             <div class="row">
-                <div class="col-sm-12 text-center">
+                <div class="text-center col-sm-12">
 
                     <a href="https://github.com/djangopackages/djangopackages">Repo</a>
 
@@ -175,9 +175,9 @@
 
                     <a href="{% url 'terms' %}">{% trans "Terms" %}</a>
 
-                    <a href="https://docs.djangopackages.org/en/latest/contributing.html">{% trans "Contribute" %}</a>
+                    <a href="https://docs.djangopackages.org/en/latest/contributing">{% trans "Contribute" %}</a>
 
-                    <a href="https://docs.djangopackages.org/en/latest/apiv3_docs.html">{% trans "API" %}</a>
+                    <a href="https://docs.djangopackages.org/en/latest/apiv3_docs">{% trans "API" %}</a>
 
                     <a href="{% url 'syndication' %}">{% trans "RSS / Atom" %}</a>
 

--- a/templates/pages/faq.html
+++ b/templates/pages/faq.html
@@ -67,7 +67,7 @@
                 <h3>How can I contribute?</h3>
 
                 <p>This is an open source project, and we appreciate
-                    <a href="https://docs.djangopackages.org/en/latest/contributing.html">all sorts of contributions</a>.
+                    <a href="https://docs.djangopackages.org/en/latest/contributing">all sorts of contributions</a>.
                 </p>
 
             </div>


### PR DESCRIPTION
With the recent move to Mkdocs, all of the links to the documentation were broken as the `.html` file ending is not handled by it.