### PR TITLE
:hammer: Remove packages from the homepage with blank repo_descriptions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,6 +70,7 @@ repos:
     rev: 'v0.0.259'
     hooks:
       - id: ruff
+        args: [--fix]
         alias: autoformat
   # - repo: https://github.com/codespell-project/codespell
   #   rev: v2.2.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,3 +83,14 @@ repos:
   #   hooks:
   #     - id: tryceratops
   #       args: [--ignore, TC101, --ignore, TC200]
+  # - repo: local
+  #   hooks:
+  #     - id: rustywind
+  #       name: rustywind Tailwind CSS class linter
+  #       language: node
+  #       additional_dependencies:
+  #         - rustywind@0.15.3
+  #       entry: rustywind
+  #       args: [--write]
+  #       types_or: [html]
+  #       # exclude: '.*\.min\.css'

--- a/homepage/tests/test_views.py
+++ b/homepage/tests/test_views.py
@@ -43,7 +43,7 @@ from django.urls.exceptions import NoReverseMatch
 
 def test_homepage(db, tp, django_assert_num_queries):
     url = tp.reverse("home")
-    with django_assert_num_queries(6):
+    with django_assert_num_queries(7):
         response = tp.client.get(url)
     assert response.status_code == 200
 

--- a/homepage/views.py
+++ b/homepage/views.py
@@ -1,4 +1,3 @@
-from random import sample
 
 from django.contrib.auth.models import User
 from django.core.cache import cache

--- a/homepage/views.py
+++ b/homepage/views.py
@@ -226,20 +226,15 @@ def homepage(request, template_name="homepage.html"):
         # cache dict for 5 minutes...
         cache.set("categories", categories, timeout=60 * 5)
 
-    # get up to 5 random packages
+    # Get package count()
     package_count = Package.objects.active().count()
-    random_packages = []
-    if package_count:
-        # Get 5 random keys
-        package_ids = sample(
-            range(1, package_count + 1),  # generate a list from 1 to package_count +1
-            min(
-                package_count,
-                10,  # Get a sample of the smallest of 10 or the package count
-            ),
-        )
-        # Get the random packages
-        random_packages = Package.objects.active().filter(pk__in=package_ids)[:5]
+
+    # Get the random packages
+    random_packages = (
+        Package.objects.active()
+        .exclude(repo_description__in=[None, ""])
+        .order_by("?")[:5]
+    )
 
     # try:
     #     potw = Dpotw.objects.latest().package
@@ -262,10 +257,15 @@ def homepage(request, template_name="homepage.html"):
     #     psa_body = '<p>There are currently no announcements.  To request a PSA, tweet at <a href="http://twitter.com/open_comparison">@Open_Comparison</a>.</p>'
 
     # Latest Django Packages blog post on homepage
-    latest_packages = Package.objects.active().order_by("-created")[:5]
+    latest_packages = (
+        Package.objects.active()
+        # .exclude(repo_description__in=[None, ""])
+        .order_by("-created")[:5]
+    )
     latest_python3 = (
         Version.objects.filter(supports_python3=True)
         .select_related("package")
+        .exclude(package__repo_description__in=[None, ""])
         .distinct()
         .order_by("-created")[:5]
     )


### PR DESCRIPTION
I was annoyed at seeing blank `repo_description`s on the homepage. 

I left the latest packages as-is to avoid not seeing new packages. 