### PR TITLE
Add Carbon Ads

### DIFF
--- a/templates/grid/grid_detail.html
+++ b/templates/grid/grid_detail.html
@@ -15,12 +15,11 @@
 
 {% block extra_head %}
     {{ block.super }}
-    {% include 'includes/_ethicalads-js.html' %}
 {% endblock %}
 
 {% block body %}
     <div class="row">
-        <div class="col-lg-6">
+        <div class="col-lg-12">
             <h2>
                 {{ grid.title|emojify|emojificate }}
                 {% if request.user.is_authenticated and profile.can_edit_grid %}
@@ -32,11 +31,8 @@
             <p>
                 {{ grid.description|emojify|emojificate|safe|urlize|linebreaksbr }}
             </p>
-        </div>
-        <div class="col-lg-6">
-            {% with ea_id="grid-detail" ea_type="text" %}
-                {% include 'includes/_ethicalads-tag.html' %}
-            {% endwith %}
+
+            <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CWYDEKJL&placement=djangopackagesorg-grid-detail" id="_carbonads_js"></script>
         </div>
     </div>
     {% cache 600 html_grid_detail_outer grid.pk request.GET.urlencode %}

--- a/templates/package/category.html
+++ b/templates/package/category.html
@@ -12,7 +12,6 @@
 
 {% block extra_head %}
     {{ block.super }}
-    {% include 'includes/_ethicalads-js.html' %}
 {% endblock %}
 
 {% block body_class %}home{% endblock %}
@@ -33,18 +32,14 @@
 
 {% block body %}
     <div class="row">
-        <div class="col-xs-6">
+        <div class="col-xs-12">
             <p>{{ category.description }}</p>
             {% if request.user.is_authenticated and profile.can_add_package %}
                 <p>
                     <a class="btn btn-primary" href="{% url 'add_package' %}">{% trans "Add Package »" %}</a>
                 </p>
             {% endif %}
-        </div>
-        <div class="col-xs-6">
-            {% with ea_id="category-detail" ea_type="text" %}
-                {% include 'includes/_ethicalads-tag.html' %}
-            {% endwith %}
+            <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CWYD55QU&placement=djangopackagesorg-category" id="_carbonads_js"></script>
         </div>
     </div>
 

--- a/templates/package/package.html
+++ b/templates/package/package.html
@@ -10,7 +10,6 @@
 {% endblock %}
 
 {% block extra_head %}
-    {% include 'includes/_ethicalads-js.html' %}
     {{ block.super }}
 {% endblock %}
 
@@ -200,9 +199,7 @@
         <div class="">
             <div class="col-md-4 sidebar">
 
-                {% with ea_id="package-detail" %}
-                    {% include 'includes/_ethicalads-tag.html' %}
-                {% endwith %}
+                <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CWYDEKJJ&placement=djangopackagesorg-detail" id="_carbonads_js"></script>
 
                 {% if package.is_deprecated %}
                     <div>

--- a/templates/package/python3_list.html
+++ b/templates/package/python3_list.html
@@ -11,7 +11,6 @@
 
 {% block extra_head %}
     {{ block.super }}
-    {% include 'includes/_ethicalads-js.html' %}
 {% endblock %}
 
 {% block body_class %}home{% endblock %}
@@ -33,9 +32,7 @@
     <div class="container">
         <div class="row">
             <div class="col-xs-12">
-                {% with ea_id="grid-detail" ea_type="text" %}
-                    {% include 'includes/_ethicalads-tag.html' %}
-                {% endwith %}
+                <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CWYDEKJL&placement=djangopackagesorg-grid-detail" id="_carbonads_js"></script>
             </div>
         </div>
         <div class="row">


### PR DESCRIPTION
Install Carbon Ads on the site. Each page will have a different zone key to track the impressions and performance separately. Some of the containers have been set to `col-lg-12` to make sure they look okay on the mobile devices.

@jefftriplett can you run it locally to see if there are any issues with the layout? I can move the ad and update the CSS if you have any preferences.