### PR TITLE
Add Utility Service to Run CronJobs

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -41,6 +41,26 @@ services:
         max-file: "5"
         # compress: "true"
 
+  utility:
+    init: true
+    build:
+      context: .
+      dockerfile: ./dockerfiles/django/Dockerfile
+    user: django
+    depends_on:
+      - redis
+    profiles:
+      - utility
+    volumes:
+      - static:/data/static
+      - media:/data/media
+    env_file: .env
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "400m"
+        max-file: "5"
+
   caddy:
     init: true
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,23 @@ services:
       - djpkg_static_dev:/data/static
       - djpkg_media_dev:/data/media
 
+  utility:
+    build:
+      context: .
+      dockerfile: ./dockerfiles/django/Dockerfile-dev
+    init: true
+    profiles:
+      - utility
+    depends_on:
+      - postgres
+      - redis
+    env_file:
+      - .env.local
+    volumes:
+      - .:/app
+      - djpkg_static_dev:/data/static
+      - djpkg_media_dev:/data/media
+
   postgres:
     build: ./dockerfiles/postgres
     hostname: postgres


### PR DESCRIPTION
With this we should be able to run:
```shell
12 23 * * * /usr/bin/docker compose -f /code/djangopackages/docker-compose.prod.yml --profile utility run --rm utility python manage.py searchv2_build
36 17 * * * /usr/bin/docker compose -f /code/djangopackages/docker-compose.prod.yml --profile utility run --rm utility python manage.py package_updater
48 21 * * * /usr/bin/docker compose -f /code/djangopackages/docker-compose.prod.yml --profile utility run --rm utility python manage.py pypi_updater
```

closes: https://github.com/djangopackages/djangopackages/issues/961