### PR TITLE
Move Load Sample Data Instructions to Installation Page

### DIFF
--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -31,25 +31,7 @@ We've done a lot of work to make it as straightforward as possible. At PyCon 201
 
 ## Supported Repo Hosting Services
 
-Django Packages supports
-
-The effort to support databases besides PostGreSQL was hampered for long time, all caused by a third party package we're not going to identify that caused grief in the use of fixtures. This was a significant issue in Django Packages, and used up a lot of development cycles.
-
-We use a **Mock** system of creating sample data in our tests and for running a development version of the site. To create some development data, just run:
-
-```shell
-docker-compose run --rm django python manage.py load_dev_data
-```
-
-Alternatively, you can use `just`
-
-```shell
-just management-command load_dev_data
-```
-
-## Unsupported Repo Hosting Services
-
-Django Packages supports GitHub and BitBucket. Here is some information about other repo hosting services.
+Django Packages supports GitHub and BitBucket.
 
 ## Troubleshooting
 

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -69,6 +69,14 @@ docker-compose run django python manage.py createsuperuser --username=joe --emai
 
 And then login into the admin interface (/admin/) and create a profile for your user filling all the fields with any data.
 
+### Load Sample Data
+
+We use a **Mock** system of creating sample data in our tests and for running a development version of the site. To create some development data, just run:
+
+```shell
+docker-compose run --rm django python manage.py load_dev_data
+```
+
 ### Formatters, Linters, and other miscellanea
 
 [Pre-commit] is a tool which helps to organize our linters and auto-formatters. Pre-commit runs before our code gets committed automatically or we may run it by hand. Pre-commit runs automatically for every pull request on GitHub too.

--- a/docs/docs/install_opinionated.md
+++ b/docs/docs/install_opinionated.md
@@ -65,6 +65,14 @@ just createsuperuser joe joe@example.com
 
 And then login into the admin interface (/admin/) and create a profile for your user filling all the fields with any data.
 
+### Load Sample Data
+
+We use a **Mock** system of creating sample data in our tests and for running a development version of the site. To create some development data, just run:
+
+```shell
+just management-command load_dev_data
+```
+
 ### just
 
 We use the command runner [just]. Install instructions are available on the [just] GitHub page.


### PR DESCRIPTION
It made more sense to move Load Sample Data Instruction to Installation Page rather than keeping it on the FAQ page. This makes it easy to discover Load Sample Data Instructions

PR Doc Build: https://djangopackages--1048.org.readthedocs.build/en/1048/install/