### PR TITLE
:sparkles: Feature flag grid and package of the week + psa

### DIFF
--- a/homepage/tests/test_views.py
+++ b/homepage/tests/test_views.py
@@ -43,7 +43,7 @@ from django.urls.exceptions import NoReverseMatch
 
 def test_homepage(db, tp, django_assert_num_queries):
     url = tp.reverse("home")
-    with django_assert_num_queries(10):
+    with django_assert_num_queries(15):
         response = tp.client.get(url)
     assert response.status_code == 200
 

--- a/homepage/views.py
+++ b/homepage/views.py
@@ -262,7 +262,7 @@ def homepage(request, template_name="homepage.html"):
     try:
         psa_body = PSA.objects.latest().body_text
     except PSA.DoesNotExist:
-        psa_body = '<p>There are currently no announcements.  To request a PSA, tweet at <a href="http://twitter.com/open_comparison">@Open_Comparison</a>.</p>'
+        psa_body = None
 
     # Latest Django Packages blog post on homepage
     latest_packages = (

--- a/templates/_homepage.html
+++ b/templates/_homepage.html
@@ -7,15 +7,15 @@
 
 
 {% switch "switch_use_grid_of_the_week" %}
-<div class="container">
-    <div class="row">
-        {% include "homepage/grid_of_the_week_partial.html" %}
-        {% include "homepage/django_package_of_the_week_partial.html" %}
-        {% switch "switch_use_psa" %}
-            {% include "homepage/public_service_announcement_partial.html" %}
-        {% endswitch %}
+    <div class="container">
+        <div class="row">
+            {% include "homepage/grid_of_the_week_partial.html" %}
+            {% include "homepage/django_package_of_the_week_partial.html" %}
+            {% switch "switch_use_psa" %}
+                {% include "homepage/public_service_announcement_partial.html" %}
+            {% endswitch %}
+        </div>
     </div>
-</div>
 {% endswitch %}
 
 

--- a/templates/_homepage.html
+++ b/templates/_homepage.html
@@ -3,22 +3,32 @@
 {% load i18n %}
 {% load package_tags %}
 {% load typogrify_tags %}
+{% load waffle_tags %}
 
+
+{% switch "switch_use_grid_of_the_week" %}
 <div class="container">
     <div class="row">
-        {% include "homepage/django_package_of_the_week_partial.html" %}
         {% include "homepage/grid_of_the_week_partial.html" %}
-        {% include "homepage/public_service_announcement_partial.html" %}
+        {% include "homepage/django_package_of_the_week_partial.html" %}
+        {% switch "switch_use_psa" %}
+            {% include "homepage/public_service_announcement_partial.html" %}
+        {% endswitch %}
     </div>
 </div>
+{% endswitch %}
+
+
 {% comment %}
 TODO: Fix this hack
 This is a hack to keep the next set of divs from wrapping up and making the display look funny
 {% endcomment %}
+
 <div class="container">
     <div class="row">
     </div>
 </div>
+
 
 <div class="container">
     <div class="row">
@@ -35,7 +45,6 @@ This is a hack to keep the next set of divs from wrapping up and making the disp
         <!-- end Categories panel -->
     </div>
 </div>
-
 
 
 <div class="container">

--- a/templates/_homepage.html
+++ b/templates/_homepage.html
@@ -1,7 +1,7 @@
+{% load emojificate %}
 {% load humanize %}
 {% load i18n %}
 {% load package_tags %}
-{% load emojificate %}
 {% load typogrify_tags %}
 
 <div class="container">

--- a/templates/homepage/django_package_of_the_week_partial.html
+++ b/templates/homepage/django_package_of_the_week_partial.html
@@ -9,6 +9,5 @@
         </p>
     {% else %}
         <p>There is no Featured Package for this week</p>
-
     {% endif %}
 </div>

--- a/templates/homepage/public_service_announcement_partial.html
+++ b/templates/homepage/public_service_announcement_partial.html
@@ -3,5 +3,11 @@
     <h2>{% trans "Public Service Announcement" %}</h2>
     {% if psa_body %}
         <p>{{ psa_body | safe }}</p>
+    {% else %}
+        <p>
+            There are currently no announcements.
+            To request a PSA, please post at <a href="https://fosstodon.org/@djangopackages">@djangopackages</a>
+            or open a <a href="https://github.com/djangopackages/djangopackages/discussions">GitHub Discussion</a>.
+        </p>
     {% endif %}
-    </div<
+</div>


### PR DESCRIPTION
The PR adds a few feature switches around the Gride of the Week + Package of the Week. The PSF flag is primarily a place holder until we swap out some copy. 