### PR TITLE
Add Missing `env_file` to docker-compose `postgres` service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
   postgres:
     # image: "pgautoupgrade/pgautoupgrade:latest"
     build: ./dockerfiles/postgres
+    env_file:
+      - .env.local
     expose:
       - 5432
     healthcheck:


### PR DESCRIPTION
In the `main` branch `docker-compose up` command was failing with this error:

```console
djangopackages-postgres-1  | 2023-12-01 08:56:41.270 UTC [261] FATAL:  password authentication failed for user "postgres"
```

After checking out the `docker-compose.yml` file I found that `env_file` field was missing from `postgres` service which caused  postgres password authentication to fail.