### PR TITLE
:tractor: Adds raw_id_fields to Profile

### DIFF
--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -18,4 +18,4 @@ def user_email(obj):
 class ProfileAdmin(VersionAdmin):
     search_fields = ("user__username", "github_account", "user__email", "email")
     list_display = ("github_account", "email", username, user_email)
-    autocomplete_fields = ["user"]
+    raw_id_fields = ["user"]


### PR DESCRIPTION
The Django admin isn’t happy with autocomplete_fields set with 18k users. Switching to raw_id_fields.