### PR TITLE
Replace Google Chart with `svg-sparkline.js` for Commit Chart Generation

### DIFF
--- a/grid/templatetags/grid_tags.py
+++ b/grid/templatetags/grid_tags.py
@@ -97,7 +97,7 @@ def style_title(value):
 
 
 def style_commits(value):
-    return render_to_string("grid/snippets/_commits.html", {"value": value})
+    return render_to_string("package/includes/_commits.html", {"value": value, "graph_width": 45})
 
 
 @register.filter

--- a/grid/templatetags/grid_tags.py
+++ b/grid/templatetags/grid_tags.py
@@ -97,7 +97,9 @@ def style_title(value):
 
 
 def style_commits(value):
-    return render_to_string("package/includes/_commits.html", {"value": value, "graph_width": 45})
+    return render_to_string(
+        "package/includes/_commits.html", {"value": value, "graph_width": 45}
+    )
 
 
 @register.filter

--- a/package/tables.py
+++ b/package/tables.py
@@ -11,7 +11,7 @@ from package.models import Package
 class PackageTable(Table):
     title = Column(empty_values=(), verbose_name="Title")
     commits = TemplateColumn(
-        '<img class="package-githubcommits" src="https://chart.googleapis.com/chart?cht=bvg&chs=105x20&chd=t:{{record.commits_over_52}}&chco=666666&chbh=1,1,1&chds=0,20" />',
+        '{% include "package/includes/_commits.html" with value=record.commits_over_52 %}',
         orderable=False,
         verbose_name="Commits",
     )

--- a/package/utils.py
+++ b/package/utils.py
@@ -1,6 +1,4 @@
-import json
 from distutils.version import LooseVersion as versioner
-from urllib.parse import urlencode
 
 from django.db import models
 from requests.compat import quote
@@ -74,49 +72,3 @@ def normalize_license(license: str):
             return "Custom"
         return stripped_license
     return "UNKNOWN"
-
-
-def build_commit_chart_url(commits):
-    chart_base_url = "https://quickchart.io/chart"
-    chart_config = {
-        "type": "bar",
-        "data": {
-            "labels": commits,
-            "datasets": [
-                {
-                    "data": commits,
-                    "backgroundColor": "#666666",
-                    "borderWidth": 1,
-                },
-            ],
-        },
-        "options": {
-            "legend": {
-                "display": False,
-            },
-            "scales": {
-                "xAxes": [
-                    {
-                        "display": False,
-                        "gridLines": {
-                            "display": False,
-                        },
-                    },
-                ],
-                "yAxes": [
-                    {
-                        "display": False,
-                        "gridLines": {
-                            "display": False,
-                        },
-                    },
-                ],
-            },
-        },
-    }
-    url_params = {
-        "width": 105,
-        "height": 20,
-        "chart": json.dumps(chart_config, separators=(",", ":")),
-    }
-    return f"{chart_base_url}?{urlencode(url_params)}"

--- a/package/utils.py
+++ b/package/utils.py
@@ -77,7 +77,7 @@ def normalize_license(license: str):
 
 
 def build_commit_chart_url(commits):
-    chart_base_url = "https://charts.googleapis.com/chart"
+    chart_base_url = "https://quickchart.io/chart"
     chart_config = {
         "type": "bar",
         "data": {

--- a/package/utils.py
+++ b/package/utils.py
@@ -1,4 +1,6 @@
+import json
 from distutils.version import LooseVersion as versioner
+from urllib.parse import urlencode
 
 from django.db import models
 from requests.compat import quote
@@ -72,3 +74,49 @@ def normalize_license(license: str):
             return "Custom"
         return stripped_license
     return "UNKNOWN"
+
+
+def build_commit_chart_url(commits):
+    chart_base_url = "https://charts.googleapis.com/chart"
+    chart_config = {
+        "type": "bar",
+        "data": {
+            "labels": commits,
+            "datasets": [
+                {
+                    "data": commits,
+                    "backgroundColor": "#666666",
+                    "borderWidth": 1,
+                },
+            ],
+        },
+        "options": {
+            "legend": {
+                "display": False,
+            },
+            "scales": {
+                "xAxes": [
+                    {
+                        "display": False,
+                        "gridLines": {
+                            "display": False,
+                        },
+                    },
+                ],
+                "yAxes": [
+                    {
+                        "display": False,
+                        "gridLines": {
+                            "display": False,
+                        },
+                    },
+                ],
+            },
+        },
+    }
+    url_params = {
+        "width": 105,
+        "height": 20,
+        "chart": json.dumps(chart_config, separators=(",", ":")),
+    }
+    return f"{chart_base_url}?{urlencode(url_params)}"

--- a/static/js/svg-sparkline.js
+++ b/static/js/svg-sparkline.js
@@ -1,0 +1,360 @@
+/*
+svg-sparkline.js 1.0.10
+
+MIT License
+
+Copyright (c) 2024 Chris Burnell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+class SVGSparkline extends HTMLElement {
+  static register(tagName) {
+    if ("customElements" in window) {
+      customElements.define(tagName || "svg-sparkline", SVGSparkline)
+    }
+  }
+
+  static css = `
+    :host {
+      display: grid;
+      display: inline-grid;
+      grid-template-columns: 1fr 1fr;
+      grid-template-rows: 1fr auto;
+    }
+    svg {
+      inline-size: auto;
+      grid-column: 1 / 3;
+      grid-row: 1 / 2;
+      padding: var(--svg-sparkline-padding, 0.375rem);
+      overflow: visible;
+    }
+    :host(:not([curve])) svg:has(title),
+    :host(:not([curve="true"])) svg:has(title) {
+      overflow-y: hidden;
+    }
+    svg[aria-hidden] {
+      pointer-events: none;
+    }
+    span {
+      padding-inline: var(--svg-sparkline-padding, 0.375rem);
+    }
+    span:nth-of-type(1) {
+      grid-column: 1 / 2;
+      text-align: start;
+    }
+    span:nth-of-type(2) {
+        grid-column: 2 / 3;
+        text-align: end;
+    }
+    @media (prefers-reduced-motion: no-preference) {
+      :host([animate]) {
+        --duration: var(--svg-sparkline-animation-duration, var(--animation-duration, 1s));
+        --first-delay: var(--svg-sparkline-animation-first-delay, var(--svg-sparkline-animation-delay, var(--animation-delay, 1s)));
+        --second-delay: var(--svg-sparkline-animation-second-delay, calc(var(--duration) + var(--first-delay)));
+      }
+      :host([animate]) svg:first-of-type {
+        clip-path: polygon(0 0, 0 0, 0 100%, 0 100%);
+      }
+      :host([visible]) svg:first-of-type {
+        animation: swipe var(--duration) linear var(--first-delay) forwards;
+      }
+      :host([animate]) svg:last-of-type,
+      :host([animate]) span {
+        opacity: 0;
+      }
+      :host([visible]) svg:last-of-type,
+      :host([visible]) span {
+        animation: fadein var(--duration) linear var(--second-delay) forwards;
+      }
+    }
+    @keyframes swipe {
+      to {
+        clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+      }
+    }
+    @keyframes fadein {
+      to {
+        opacity: 1;
+      }
+    }
+  `
+
+  static observedAttributes = ["values", "width", "height", "color", "curve", "endpoint", "endpoint-color", "endpoint-width", "fill", "gradient", "fill-color", "gradient-color", "line-width", "start-label", "end-label", "animation-duration", "animation-delay"]
+
+  connectedCallback() {
+    if (!this.getAttribute("values")) {
+      console.error(`Missing \`values\` attribute!`, this)
+      return
+    }
+
+    this.init()
+  }
+
+  render() {
+    if (!this.hasAttribute("values")) {
+      return
+    }
+
+    this.values = this.getAttribute("values").split(",")
+    this.width = parseFloat(this.getAttribute("width")) || 200
+    this.height = parseFloat(this.getAttribute("height")) || 36
+    this.color = this.getAttribute("color")
+    this.curve = this.hasAttribute("curve") && this.getAttribute("curve") !== "false"
+    this.endpoint = this.getAttribute("endpoint") !== "false"
+    this.endpointColor = this.getAttribute("endpoint-color")
+    this.endpointWidth = parseFloat(this.getAttribute("endpoint-width")) || 6
+    this.fill = this.hasAttribute("fill") && this.getAttribute("fill") !== "false"
+    this.gradient = this.hasAttribute("gradient") && this.getAttribute("gradient") !== "false"
+    this.gradientColor = this.getAttribute("fill-color") || this.getAttribute("gradient-color")
+    this.lineWidth = parseFloat(this.getAttribute("line-width")) || 2
+    this.startLabel = this.getAttribute("start-label")
+    this.endLabel = this.getAttribute("end-label")
+
+    const color = this.color || `var(--svg-sparkline-color, currentColor)`
+    const endpointColor = this.endpointColor || `var(--svg-sparkline-endpoint-color, ${color})`
+    const gradientColor = this.gradientColor || `var(--svg-sparkline-fill-color, var(--svg-sparkline-gradient-color, ${color}))`
+
+    let content = []
+
+    if (this.startLabel) {
+      content.push(`<span>${this.startLabel}</span>`)
+    }
+
+    const title = this.title || `Sparkline ranging from ${this.getMinY(this.values)} to ${this.getMaxY(this.values)}.`;
+    content.push(`
+      <svg width="${this.width}px" height="${this.height}px" viewBox="${this.getViewBox(this.values)}" preserveAspectRatio="none" role="img">
+        <title>${title}</title>
+    `)
+
+    let gradientID
+    if (this.gradient) {
+      gradientID = this.makeID(6)
+      content.push(`
+        <defs>
+          <linearGradient id="svg-sparkline-gradient-${gradientID}" gradientTransform="rotate(90)">
+            <stop offset="0%" stop-color="${gradientColor}" />
+            <stop offset="100%" stop-color="transparent" />
+          </linearGradient>
+        </defs>
+      `)
+    }
+
+    if (this.gradient || this.fill) {
+      content.push(`
+        <path
+            d="${this.getPath(this.values, this.curve)} L ${this.getFinalX(this.values)} ${this.getAdjustedMaxY(this.values)} L 0 ${this.getAdjustedMaxY(this.values)} Z"
+            fill="${this.fill ? gradientColor : `url('#svg-sparkline-gradient-${gradientID}')`}"
+            stroke="transparent"
+        />
+      `)
+    }
+
+    content.push(`
+      <path
+          d="${this.getPath(this.values, this.curve)}"
+          stroke="${color}"
+          stroke-width="${this.lineWidth}"
+          stroke-linecap="round"
+          fill="transparent"
+          vector-effect="non-scaling-stroke"
+      />
+    `)
+
+    content.push(`</svg>`)
+
+    if (this.endpoint) {
+      content.push(`
+        <svg width="${this.width}px" height="${this.height}px" viewBox="0 0 ${this.width} ${this.height}" preserveAspectRatio="xMaxYMid meet" aria-hidden="true">
+          <circle r="${this.endpointWidth / 2}" cx="${this.width}" cy="${(this.height / this.getAdjustedMaxY(this.values)) * this.getFinalY(this.values)}" fill="${endpointColor}"></circle>
+        </svg>
+      `)
+    }
+
+    if (this.endLabel) {
+      content.push(`<span>${this.endLabel}</span>`)
+    }
+
+    return content.join("")
+  }
+
+  getBaseCSS() {
+    let sheet = new CSSStyleSheet()
+    sheet.replaceSync(SVGSparkline.css)
+
+    return sheet
+  }
+
+  setCSS() {
+    let stylesheets = [this.getBaseCSS()]
+    if (this.hasAttribute("animation-duration")) {
+      let sheet = new CSSStyleSheet()
+      sheet.replaceSync(`
+        :host {
+          --animation-duration: ${this.getAttribute("animation-duration")};
+        }
+      `)
+      stylesheets.push(sheet)
+    }
+    if (this.hasAttribute("animation-delay")) {
+      let sheet = new CSSStyleSheet()
+      sheet.replaceSync(`
+        :host {
+          --animation-delay: ${this.getAttribute("animation-delay")};
+        }
+      `)
+      stylesheets.push(sheet)
+    }
+    this.shadowRoot.adoptedStyleSheets = stylesheets
+  }
+
+  initTemplate() {
+    if (this.shadowRoot) {
+      if (this.innerHTML.trim() === "") {
+        this.shadowRoot.innerHTML = this.render()
+      } else {
+        this.shadowRoot.innerHTML = this.innerHTML
+        this.innerHTML = ""
+      }
+      return
+    }
+
+    this.attachShadow({ mode: "open" })
+
+    this.setCSS()
+
+    let template = document.createElement("template")
+    template.innerHTML = this.render()
+    this.shadowRoot.appendChild(template.content.cloneNode(true))
+
+    const threshold = Math.min(Math.max(Number(this.getAttribute("threshold") || 0.333), 0), 1)
+
+    if (this.hasAttribute("animate")) {
+      const observer = new IntersectionObserver(
+        (entries, observer) => {
+          if (entries[0].intersectionRatio > threshold) {
+            this.setAttribute("visible", true)
+            observer.unobserve(this)
+          }
+        },
+        { threshold: threshold }
+      )
+      observer.observe(this)
+    }
+  }
+
+  init() {
+    this.initTemplate()
+  }
+
+  attributeChangedCallback() {
+    this.initTemplate()
+    this.setCSS()
+  }
+
+  maxDecimals(value, decimals = 2) {
+    return +value.toFixed(decimals)
+  }
+
+  getViewBox(values) {
+    return `0 0 ${values.length - 1} ${this.getAdjustedMaxY(values)}`
+  }
+
+  lineCommand(point, i) {
+    return `L ${i},${point}`
+  }
+
+  line(ax, ay, bx, by) {
+    const lengthX = bx - ax
+    const lengthY = by - ay
+
+    return {
+      length: Math.sqrt(Math.pow(lengthX, 2) + Math.pow(lengthY, 2)),
+      angle: Math.atan2(lengthY, lengthX),
+    }
+  }
+
+  controlPoint(cx, cy, px, py, nx, ny, reverse) {
+    // When the current X,Y are the first or last point of the array,
+    // previous or next X,Y don't exist. Replace with current X,Y.
+    px = px || cx
+    py = py || cy
+    nx = nx || cx
+    ny = ny || cy
+
+    const line = this.line(px, py, nx, ny)
+
+    const smoothing = 0.2
+    const angle = line.angle + (reverse ? Math.PI : 0)
+    const length = line.length * smoothing
+
+    const x = cx + Math.cos(angle) * length
+    const y = cy + Math.sin(angle) * length
+
+    return [x, y]
+  }
+
+  bezierCommand(point, i, a, maxY) {
+    const [csx, csy] = this.controlPoint(i - 1, a[i - 1], i - 2, a[i - 2], i, point)
+    const [cex, cey] = this.controlPoint(i, point, i - 1, a[i - 1], i + 1, a[i + 1], true)
+
+    return `C ${this.maxDecimals(csx)},${Math.min(maxY, this.maxDecimals(csy))} ${this.maxDecimals(cex)},${Math.min(maxY, this.maxDecimals(cey))} ${i},${point}`
+  }
+
+  getPath(values, curve) {
+    return (
+      values
+        // flips each point in the vertical range
+        .map((point) => Math.max(...values) - point + 1)
+        // generate a string
+        .reduce((acc, point, i, a) => {
+          return i < 1 ? `M 0,${point}` : `${acc} ${curve ? this.bezierCommand(point, i, a, this.getAdjustedMaxY(values)) : this.lineCommand(point, i)}`
+        }, "")
+    )
+  }
+
+  getFinalX(values) {
+    return values.length - 1
+  }
+
+  getFinalY(values) {
+    return Math.max(...values) - values[values.length - 1] + 1
+  }
+
+  getMinY(values) {
+    return Math.min(...values)
+  }
+
+  getMaxY(values) {
+    return Math.max(...values)
+  }
+
+  getAdjustedMaxY(values) {
+    return this.getMaxY(values) + 1
+  }
+
+  makeID(length) {
+    const SEQUENCE = "0123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+    return Array.from({ length: length }).reduce((id, _) => {
+      return id + SEQUENCE.charAt(Math.floor(Math.random() * SEQUENCE.length))
+    }, "")
+  }
+}
+
+SVGSparkline.register()

--- a/templates/base.html
+++ b/templates/base.html
@@ -223,6 +223,7 @@
             <script src="{{ STATIC_URL }}js/jquery.tablesorter.min.js" type="text/javascript"></script>
             <script src="{{ STATIC_URL }}js/jquery.tools.min.js" type="text/javascript"></script>
             <script src="{{ STATIC_URL }}js/site.js" type="text/javascript"></script>
+            <script type="module" src="{{ STATIC_URL }}js/svg-sparkline.js"></script>
         {% endblock javascript %}
 
         <script async defer src="https://scripts.simpleanalyticscdn.com/latest.js"></script>

--- a/templates/grid/grid_detail.html
+++ b/templates/grid/grid_detail.html
@@ -141,7 +141,7 @@
                     <tr>
                         <td>{% trans "Commits" %}</td>
                         {% for grid_package in grid_packages %}
-                            <td><img class="package-githubcommits" src="https://chart.googleapis.com/chart?cht=bvg&chs=105x20&chd=t:{{ grid_package.package|commits_over_52 }}&chco=666666&chbh=1,1,1&chds=0,20" /></td>
+                            <td>{% include "package/includes/_commits.html" with value=grid_package.package.commits_over_52 %}</td>
                         {% endfor %}
                     </tr>
                     <tr>
@@ -291,9 +291,7 @@
 {% endblock %}
 
 {% block extra_body %}
-    <script type="text/javascript" src="{{ STATIC_URL }}js/rtd.js"></script>
     <script type="text/javascript">
-
         $(function() {
 
             {% if request.user.is_authenticated %}

--- a/templates/grid/grid_detail_landscape.html
+++ b/templates/grid/grid_detail_landscape.html
@@ -11,14 +11,9 @@
 {% endblock %}
 
 {% block javascript %}
-    <script src="{{ STATIC_URL }}bower_components/jquery/jquery.min.js" type="text/javascript"></script>
+    {{ block.super }}
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.4/jquery-ui.min.js"></script>
-    <script src="{{ STATIC_URL }}components/audreyr-rotatingnav/dist/jquery.rotatingnav.min.js"></script>
-    <script src="{{ STATIC_URL }}components/audreyr-topbar/dist/jquery.topbar.min.js"></script>
-    <script src="{{ STATIC_URL }}js/jquery.tablesorter.min.js" type="text/javascript"></script>
     <script src="{{ STATIC_URL }}js/jquery.dataTables.min.js" type="text/javascript"></script>
-    <script src="{{ STATIC_URL }}js/jquery.tools.min.js" type="text/javascript"></script>
-    <script src="{{ STATIC_URL }}js/site.js" type="text/javascript"></script>
 {% endblock javascript %}
 
 {% block body %}

--- a/templates/grid/snippets/_commits.html
+++ b/templates/grid/snippets/_commits.html
@@ -1,1 +1,0 @@
-<img class="package-githubcommits" src="https://chart.googleapis.com/chart?cht=bvg&chs=105x20&chd=t:{{ value }}&chco=666666&chbh=1,1,1&chds=0,20" />

--- a/templates/package/includes/_commits.html
+++ b/templates/package/includes/_commits.html
@@ -1,0 +1,1 @@
+<svg-sparkline class="package-githubcommits" values="{{ value }}" line-width="0.4" color="#0C3C26" gradient="true" gradient-color="#0C3C26" width="{{ graph_width|default:70 }}" height="{{ graph_height|default:20 }}" endpoint="false" curve="true"></svg-sparkline>

--- a/templates/package/package.html
+++ b/templates/package/package.html
@@ -117,8 +117,8 @@
                 <tbody>
                     <tr>
                         <td><a href="{{ package.repo_url }}">{{ package.repo_url }}</a></td>
-                        <td><img
-                            src="https://chart.googleapis.com/chart?cht=bvg&chs=105x20&chd=t:{{ package.commits_over_52 }}&chco=666666&chbh=1,1,1&chds=0,20"/>
+                        <td>
+                            {% include "package/includes/_commits.html" with value=package.commits_over_52 %}
                         </td>
                         <td>{{ package.repo_watchers|default:"n/a" }}</td>
                         <td>{{ package.repo_forks|default:"n/a" }}</td>


### PR DESCRIPTION
closes https://github.com/djangopackages/djangopackages/issues/1128

I was able generate this image URL (DRF Commit Graph) using the script on the PR.

![image](https://quickchart.io/chart?width=105&height=20&chart=%7B%22type%22%3A%22bar%22%2C%22data%22%3A%7B%22labels%22%3A%5B1%2C1%2C4%2C1%2C4%2C1%2C2%2C2%2C6%2C3%2C0%2C1%2C1%2C1%2C3%2C0%2C1%2C8%2C0%2C1%2C0%2C2%2C0%2C0%2C4%2C2%2C3%2C0%2C0%2C1%2C0%2C0%2C3%2C1%2C0%2C0%2C0%2C4%2C1%2C1%2C5%2C2%2C0%2C1%2C5%2C3%2C4%2C3%2C7%2C10%2C1%2C1%5D%2C%22datasets%22%3A%5B%7B%22data%22%3A%5B1%2C1%2C4%2C1%2C4%2C1%2C2%2C2%2C6%2C3%2C0%2C1%2C1%2C1%2C3%2C0%2C1%2C8%2C0%2C1%2C0%2C2%2C0%2C0%2C4%2C2%2C3%2C0%2C0%2C1%2C0%2C0%2C3%2C1%2C0%2C0%2C0%2C4%2C1%2C1%2C5%2C2%2C0%2C1%2C5%2C3%2C4%2C3%2C7%2C10%2C1%2C1%5D%2C%22backgroundColor%22%3A%22%23666666%22%2C%22borderWidth%22%3A1%7D%5D%7D%2C%22options%22%3A%7B%22legend%22%3A%7B%22display%22%3Afalse%7D%2C%22scales%22%3A%7B%22xAxes%22%3A%5B%7B%22display%22%3Afalse%2C%22gridLines%22%3A%7B%22display%22%3Afalse%7D%7D%5D%2C%22yAxes%22%3A%5B%7B%22display%22%3Afalse%2C%22gridLines%22%3A%7B%22display%22%3Afalse%7D%7D%5D%7D%7D%7D)

> `https://quickchart.io/chart?width=105&height=20&chart=%7B%22type%22%3A%22bar%22%2C%22data%22%3A%7B%22labels%22%3A%5B1%2C1%2C4%2C1%2C4%2C1%2C2%2C2%2C6%2C3%2C0%2C1%2C1%2C1%2C3%2C0%2C1%2C8%2C0%2C1%2C0%2C2%2C0%2C0%2C4%2C2%2C3%2C0%2C0%2C1%2C0%2C0%2C3%2C1%2C0%2C0%2C0%2C4%2C1%2C1%2C5%2C2%2C0%2C1%2C5%2C3%2C4%2C3%2C7%2C10%2C1%2C1%5D%2C%22datasets%22%3A%5B%7B%22data%22%3A%5B1%2C1%2C4%2C1%2C4%2C1%2C2%2C2%2C6%2C3%2C0%2C1%2C1%2C1%2C3%2C0%2C1%2C8%2C0%2C1%2C0%2C2%2C0%2C0%2C4%2C2%2C3%2C0%2C0%2C1%2C0%2C0%2C3%2C1%2C0%2C0%2C0%2C4%2C1%2C1%2C5%2C2%2C0%2C1%2C5%2C3%2C4%2C3%2C7%2C10%2C1%2C1%5D%2C%22backgroundColor%22%3A%22%23666666%22%2C%22borderWidth%22%3A1%7D%5D%7D%2C%22options%22%3A%7B%22legend%22%3A%7B%22display%22%3Afalse%7D%2C%22scales%22%3A%7B%22xAxes%22%3A%5B%7B%22display%22%3Afalse%2C%22gridLines%22%3A%7B%22display%22%3Afalse%7D%7D%5D%2C%22yAxes%22%3A%5B%7B%22display%22%3Afalse%2C%22gridLines%22%3A%7B%22display%22%3Afalse%7D%7D%5D%7D%7D%7D`

**QuickChart Docs:** https://quickchart.io/documentation/
**Community License:** GNU GPL v3 license
**Community Pricing:** $0/month (https://quickchart.io/pricing/)

**Note:** This is a draft experiment, we can choose to use a different service for this as well. (We can always use chartjs directly)