### PR TITLE
:art: urlize extra field url value

### DIFF
--- a/templates/profiles/profile.html
+++ b/templates/profiles/profile.html
@@ -41,7 +41,7 @@
 
             {% if extra_fields%}
                 {% for field in extra_fields%}
-                    <p><b>{{ field.label }}:</b> {{ field.url }}</p>
+                    <p><b>{{ field.label }}:</b> {{ field.url|urlize }}</p>
                 {% endfor%}
             {% endif %}
 


### PR DESCRIPTION
I verified that `rel="nofollow"` is included for free. 

```html
<p><b>Mastodon:</b> <a href="https://mastodon.social/@webology" rel="nofollow">https://mastodon.social/@webology</a></p>
 ```