### PR TITLE
:bug: Fix broken python3 using this filter

### DIFF
--- a/package/tables.py
+++ b/package/tables.py
@@ -32,6 +32,7 @@ class PackageTable(Table):
     #     <span class="usage-count">{{ package.usage_count }}</span>
     # </td>
     # <td>{{ package.last_released.pretty_status }}</td>
+
     # "# Using This"
     usage_count = TemplateColumn(
         '<span class="usage-count">{{ record.usage_count }}</span>',

--- a/package/views.py
+++ b/package/views.py
@@ -461,6 +461,7 @@ class PackagePython3ListView(SingleTableView):
         return (
             Package.objects.filter(version__supports_python3=True)
             .select_related()
+            .annotate(usage_count=Count("usage"))
             .distinct()
             .order_by("-pypi_downloads", "-repo_watchers", "title")
         )


### PR DESCRIPTION
This fixes out #1 Sentry bug a month. 

```
{'code': 500, 'request': 'GET /python3/?dir=asc&page=82&sort=-usage_count', 'event': 'request_fai...
```
