### PR TITLE
:sparkles: Adds pypi_update_top_package_stats management command

### DIFF
--- a/package/management/commands/pypi_update_top_package_stats.py
+++ b/package/management/commands/pypi_update_top_package_stats.py
@@ -1,0 +1,46 @@
+import djclick as click
+import httpx
+
+from package.models import Package
+from rich import print
+
+
+DOWNLOAD_PATH = "top-pypi-packages-30-days.min.json"
+DOWNLOAD_URL = "https://raw.githubusercontent.com/hugovk/top-pypi-packages/main/top-pypi-packages-30-days.min.json"
+
+
+def normalize_pypi_slug(url: str) -> str:
+    url = url.replace("http:", "https:")
+    url = url.strip("/")
+    url = url.split("/")[-1]
+    return url
+
+
+@click.command()
+@click.argument("url", type=str, default=DOWNLOAD_URL)
+def command(url):
+    package_lookup = {}
+
+    request = httpx.get(url)
+    request.raise_for_status()
+
+    data = request.json()
+    print(f"last_update: {data['last_update']}")
+
+    rows = data["rows"]
+    for row in rows:
+        project = row["project"]
+        download_count = row["download_count"]
+        package_lookup[project] = download_count
+
+    objs = []
+    packages = Package.objects.exclude(pypi_url__in=[None, ""]).order_by("pypi_url")
+    for package in packages:
+        pypi_slug = normalize_pypi_slug(package.pypi_url)
+        if pypi_slug in package_lookup:
+            package.pypi_downloads = package_lookup.get("pypi_slug", 0)
+            objs.append(package)
+
+    if len(objs):
+        print(f"bulk updating... {len(objs)} objects")
+        Package.objects.bulk_update(objs, ["pypi_downloads"])


### PR DESCRIPTION
Related to #1065 and #834

This pulls data for the top 8000 Python packages which hits about 4 to 5% of our packages which isn't great. 

I have another management command that requires Seth's monthly file download, but it's a little clunky. 