### PR TITLE
:elephant: Adds pg_dump and pg_restore recipes

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -40,7 +40,7 @@ services:
       retries: 30
     init: true
     volumes:
-      - djpkg_postgres_data_dev:/var/lib/postgresql/data
+      - .:/app
 
   redis:
     image: redis:7

--- a/justfile
+++ b/justfile
@@ -2,6 +2,8 @@ set dotenv-load := false
 
 alias pip-compile := lock
 
+DATABASE_URL := env_var_or_default('DATABASE_URL', 'postgres://djangopackages:djangopackages@postgres/djangopackages')
+
 @_default:
     just --list
 
@@ -270,3 +272,29 @@ bootstrap *ARGS:
 @tailwind-watch:
     just tailwind-build
     just tailwind --watch
+
+# dump database to file
+@pg_dump file='db.dump':
+    docker compose run \
+        --no-deps \
+        --rm \
+        postgres \
+        pg_dump \
+            --dbname "{{ DATABASE_URL }}" \
+            --file /app/{{ file }} \
+            --format=c \
+            --verbose
+
+# restore database dump from file
+@pg_restore file='db.dump':
+    docker compose run \
+        --no-deps \
+        --rm \
+        postgres \
+        pg_restore \
+            --clean \
+            --dbname "{{ DATABASE_URL }}" \
+            --if-exists \
+            --no-owner \
+            --verbose \
+            /app/{{ file }}


### PR DESCRIPTION
This adds a few convenience `just` recipes:

- `just pg_dump`
- `just pg_restore`

It also exposed the `/app` volume to the database service container so that we can see backup files. 