### PR TITLE
:arrow_up: Bumps for Django 5.1 and Python 3.13

### DIFF
--- a/homepage/views.py
+++ b/homepage/views.py
@@ -27,6 +27,7 @@ class OpenView(TemplateView):
             "total_django_4_1": "Framework :: Django :: 4.1",
             "total_django_4_2": "Framework :: Django :: 4.2",
             "total_django_5_0": "Framework :: Django :: 5.0",
+            "total_django_5_1": "Framework :: Django :: 5.1",
             "total_python_2_7": "Programming Language :: Python :: 2.7",
             "total_python_3": "Programming Language :: Python :: 3",
             "total_python_3_6": "Programming Language :: Python :: 3.6",
@@ -36,6 +37,7 @@ class OpenView(TemplateView):
             "total_python_3_10": "Programming Language :: Python :: 3.10",
             "total_python_3_11": "Programming Language :: Python :: 3.11",
             "total_python_3_12": "Programming Language :: Python :: 3.12",
+            "total_python_3_13": "Programming Language :: Python :: 3.13",
         }
         vcs_providers = {
             "repos_bitbucket": "bitbucket.org",

--- a/templates/pages/open.html
+++ b/templates/pages/open.html
@@ -40,6 +40,7 @@
             </div>
             <div class="col-sm-6 col-md-3">
                 <h2>{% trans "Django Versions" %}</h2>
+                <p>{% trans "Django 5.1 Packages:" %} {{ total_django_5_1|intcomma }}</p>
                 <p>{% trans "Django 5.0 Packages:" %} {{ total_django_5_0|intcomma }}</p>
                 <p>{% trans "Django 4.2 Packages:" %} {{ total_django_4_2|intcomma }}</p>
                 <p>{% trans "Django 4.1 Packages:" %} {{ total_django_4_1|intcomma }}</p>
@@ -49,6 +50,7 @@
             <div class="col-sm-6 col-md-3">
                 <h2>{% trans "Python Versions" %}</h2>
                 <p>{% trans "Python 3 Packages:" %} {{ total_python_3|intcomma }}</p>
+                <p>{% trans "Python 3.13 Packages:" %} {{ total_python_3_13|intcomma }}</p>
                 <p>{% trans "Python 3.12 Packages:" %} {{ total_python_3_12|intcomma }}</p>
                 <p>{% trans "Python 3.11 Packages:" %} {{ total_python_3_11|intcomma }}</p>
                 <p>{% trans "Python 3.10 Packages:" %} {{ total_python_3_10|intcomma }}</p>


### PR DESCRIPTION
Updates to prep for tracking Django 5.1 and Python 3.13. 

- https://djangopackages.org/open/
- https://djangopackages.org/readiness/
