### PR TITLE
Fix Large Grid Display Issue

### DIFF
--- a/templates/grid/grid_detail.html
+++ b/templates/grid/grid_detail.html
@@ -58,7 +58,7 @@
                     {% include "grid/snippets/grid_row_header.html" %}
                 </thead>
             </table>
-            <table class="table table-condensed">
+            <table class="table table-condensed" style="display: block; max-width: fit-content; overflow-x: auto;">
                 <thead>
                     {% include "grid/snippets/grid_row_header.html" %}
                 </thead>


### PR DESCRIPTION
This PR adds overflow scrollbar for large grids, which used to break the UI.

**Example:** https://djangopackages.org/grids/g/admin-interface/

**Before:**
![Screenshot from 2024-08-21 17-37-59](https://github.com/user-attachments/assets/8b60da3f-1067-4805-8c13-3d5bab9628aa)

**After:**
![Screenshot from 2024-08-21 17-37-33](https://github.com/user-attachments/assets/7c21d546-7675-48c9-9b36-1aa9ec3f99d1)
