### PR TITLE
:fire: Removes `--reuse-db` testing option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ tag = true
 ]
 
 [tool.pytest.ini_options]
-addopts = "--durations=1 --nomigrations --reuse-db -vv"
+addopts = "--durations=1 --nomigrations"
 DJANGO_SETTINGS_MODULE = "settings.test"
 norecursedirs = ".git config node_modules scss settings sponsors static templates"
 python_files = "test_*.py"


### PR DESCRIPTION
Fixes #1235 

`--reuse-db` is a nice default but it trips anyone who is new up when a database change doesn't get applied. 