### PR TITLE
:gear: :whale: Adds missing `--profile` option

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -199,5 +199,7 @@ def docker_compose(command, old=True):
     """
     with env.cd(env.project_dir):
         if env.compose_version == "v2":
-            return env.run(f"docker compose -f {env.compose_file} --profile utility {command}")
+            return env.run(
+                f"docker compose -f {env.compose_file} --profile utility {command}"
+            )
         return env.run(f"docker-compose -f {env.compose_file} {command}")

--- a/fabfile.py
+++ b/fabfile.py
@@ -199,5 +199,5 @@ def docker_compose(command, old=True):
     """
     with env.cd(env.project_dir):
         if env.compose_version == "v2":
-            return env.run(f"docker compose -f {env.compose_file} {command}")
+            return env.run(f"docker compose -f {env.compose_file} --profile utility {command}")
         return env.run(f"docker-compose -f {env.compose_file} {command}")


### PR DESCRIPTION
This was tripping up a production cron issue that wasn't obvious. The `django-a` and `django-b` services were rebuilding, but the `utility` service wasn't getting a newer profile to rebuild. 