### PR TITLE
✨ Adds delay option to pypi_stats

### DIFF
--- a/package/management/commands/pypi_stats.py
+++ b/package/management/commands/pypi_stats.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 import djclick as click
 import json
@@ -13,7 +14,10 @@ logger = logging.getLogger(__name__)
 
 @click.command()
 @click.option("--slug", type=str, default=None)
-def command(slug):
+@click.option(
+    "--delay", type=float, default=2.0, help="Delay between API calls in seconds"
+)
+def command(slug, delay):
     if slug:
         packages = Package.objects.filter(slug=slug)
     else:
@@ -30,6 +34,10 @@ def command(slug):
 
             package.pypi_downloads = pypi_downloads
             package.save(update_fields=["pypi_downloads"])
+
+            # Delay between API calls to avoid rate limiting
+            logger.debug(f"Delaying for {delay} seconds...")
+            time.sleep(delay)
 
         except Exception as e:
             print(f"{e=}")


### PR DESCRIPTION
Production test for #1289 

Locally, I run `pypi_stats` without a delay, but in production we can only get one request off before being throttled. 

We intend to be good citizens, but I was surprised to find that the two environments differ so much. 

The limit appears to be `"5 per second", or "30 per minute,"` so a 5-second delay should be plenty. 

https://github.com/crflynn/pypistats.org/blob/70a10f994173b4b9e8905fb3494dd5d0d5bd1bbb/pypistats/run.py#L23