### PR TITLE
Integrate score value into Package/Grid results #1063

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -38,3 +38,9 @@ def current_path(request):
     if request.path.strip() != reverse("logout"):
         context["current_path"] = request.path
     return context
+
+
+def settings_context(request):
+    return {
+        "TEST_MODE": settings.TEST_MODE,
+    }

--- a/grid/tests/test_views.py
+++ b/grid/tests/test_views.py
@@ -108,7 +108,7 @@ class FunctionalGridTest(TestCase):
             response,
             dedent(
                 """
-                    <td>
+                    <td data-testid="grid-detail-score-header">
                         Score
                         <span
                             class="glyphicon glyphicon-info-sign"
@@ -127,7 +127,7 @@ class FunctionalGridTest(TestCase):
                 response,
                 dedent(
                     f"""
-                        <td>
+                        <td data-testid="grid-{package.slug}-detail-score-cell">
                             {intcomma(package.score)}
                         </td>
                     """

--- a/grid/tests/test_views.py
+++ b/grid/tests/test_views.py
@@ -114,7 +114,7 @@ class FunctionalGridTest(TestCase):
                             class="glyphicon glyphicon-info-sign"
                             data-toggle="tooltip"
                             data-placement="top"
-                            title="Scores (0-100) are based on GitHub stars, with deductions for inactivity (-10% every 3 months) and lack of Python 3 support (-30%)."
+                            title="Scores (0-100) are based on Repository stars, with deductions for inactivity (-10% every 3 months) and lack of Python 3 support (-30%)."
                         ></span>
                     </td>
                 """

--- a/grid/views.py
+++ b/grid/views.py
@@ -364,6 +364,7 @@ def grid_detail(request, slug, template_name="grid/grid_detail.html"):
         ("repo", "Repo"),
         ("commits_over_52", "Commits"),
         ("repo_watchers", "Stars"),
+        ("score", "Score"),
         ("repo_forks", "Forks"),
         ("participant_list", "Participants"),
         ("license_latest", "License"),

--- a/package/tests/test_views.py
+++ b/package/tests/test_views.py
@@ -114,6 +114,7 @@ class FunctionalPackageTest(TestCase):
             response,
             dedent("""
                 <th
+                    data-testid="repository-statistics-score-header"
                     scope="col"
                     aria-label="Score"
                     data-toggle="tooltip"
@@ -127,7 +128,12 @@ class FunctionalPackageTest(TestCase):
         )
         self.assertContains(
             response,
-            f"""<td>{intcomma(package.score)}</td>""",
+            dedent(f"""
+                <td data-testid="repository-statistics-score-cell">
+                    {intcomma(package.score)}
+                </td>
+            """),
+            html=True,
         )
 
     def test_latest_packages_view(self):

--- a/package/tests/test_views.py
+++ b/package/tests/test_views.py
@@ -118,7 +118,7 @@ class FunctionalPackageTest(TestCase):
                     aria-label="Score"
                     data-toggle="tooltip"
                     data-placement="top"
-                    title="Scores (0-100) are based on GitHub stars, with deductions for inactivity (-10% every 3 months) and lack of Python 3 support (-30%)."
+                    title="Scores (0-100) are based on Repository stars, with deductions for inactivity (-10% every 3 months) and lack of Python 3 support (-30%)."
                 >
                     <span class="glyphicon glyphicon-stats"></span>
                 </th>

--- a/settings.py
+++ b/settings.py
@@ -1,11 +1,11 @@
 # Django settings
+import os.path
 import sys
 from pathlib import Path
-import os.path
 
+import environ
 import sentry_sdk
 import structlog
-import environ
 from django.template.defaultfilters import slugify
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
@@ -156,6 +156,7 @@ TEMPLATES = [
                 "social_django.context_processors.backends",
                 "social_django.context_processors.login_redirect",
                 "core.context_processors.core_values",
+                "core.context_processors.settings_context",
             ],
         },
     },

--- a/templates/base.html
+++ b/templates/base.html
@@ -239,6 +239,18 @@
 
         {% block extra_body %}{% endblock %}
 
+        <!-- Start of Bootstrap initialization -->
+        <script src="{% static 'bower_components/bootstrap/dist/js/bootstrap.min.js' %}" defer></script>
+        <script type="text/javascript">
+            $(function() {
+                // Enable tooltips sidewide
+                $('[data-toggle="tooltip"]').tooltip({
+                    container: 'body',
+                });
+            });
+        </script>
+        <!-- End of Bootstrap initialization -->
+
         {{ PIWIK_CODE|safe }}
     </body>
 </html>

--- a/templates/grid/grid_detail.html
+++ b/templates/grid/grid_detail.html
@@ -302,11 +302,6 @@
 
 {% endblock body %}
 
-{% block javascript %}
-    {{ block.super }}
-    <script src="{{ STATIC_URL }}bower_components/bootstrap/dist/js/bootstrap.min.js" defer></script>
-{% endblock javascript %}
-
 {% block extra_body %}
     <script type="text/javascript">
         $(function() {
@@ -377,11 +372,6 @@
 
             $("#filterForm").on("input", function() {
                 this.submit();
-            });
-
-            // Enable tooltips
-            $('[data-toggle="tooltip"]').tooltip({
-                container: 'body',
             });
         });
     </script>

--- a/templates/grid/grid_detail.html
+++ b/templates/grid/grid_detail.html
@@ -151,7 +151,7 @@
                                 class="glyphicon glyphicon-info-sign"
                                 data-toggle="tooltip"
                                 data-placement="top"
-                                title="{% translate 'Scores (0-100) are based on GitHub stars, with deductions for inactivity (-10% every 3 months) and lack of Python 3 support (-30%).' %}"
+                                title="{% translate 'Scores (0-100) are based on Repository stars, with deductions for inactivity (-10% every 3 months) and lack of Python 3 support (-30%).' %}"
                             ></span>
                         </td>
                         {% for grid_package in grid_packages %}

--- a/templates/grid/grid_detail.html
+++ b/templates/grid/grid_detail.html
@@ -1,6 +1,6 @@
 {% extends "grid/base.html" %}
 
-{% load cache crispy_forms_tags emojificate grid_tags humanize i18n package_tags page_metadata_tags %}
+{% load cache crispy_forms_tags emojificate grid_tags humanize i18n package_tags page_metadata_tags waffle_tags %}
 
 {% block metadata %}
     {% page_metadata page_title=grid.title page_description=grid.description page_keywords=grid.packages.all|join:',' og_image_url=grid.get_opengraph_image_url %}
@@ -144,22 +144,24 @@
                             <td>{{ grid_package.package.repo_watchers|intcomma|default:"n/a" }}</td>
                         {% endfor %}
                     </tr>
-                    <tr>
-                        <td {% if TEST_MODE %}data-testid="grid-detail-score-header"{% endif %}>
-                            {% translate "Score" %}
-                            <span
-                                class="glyphicon glyphicon-info-sign"
-                                data-toggle="tooltip"
-                                data-placement="top"
-                                title="{% translate 'Scores (0-100) are based on Repository stars, with deductions for inactivity (-10% every 3 months) and lack of Python 3 support (-30%).' %}"
-                            ></span>
-                        </td>
-                        {% for grid_package in grid_packages %}
-                            <td {% if TEST_MODE %}data-testid="grid-{{ grid_package.package.slug }}-detail-score-cell"{% endif %}>
-                                {{ grid_package.package.score|intcomma|default:"n/a" }}
+                    {% flag "enabled_packages_score_values" %}
+                        <tr>
+                            <td {% if TEST_MODE %}data-testid="grid-detail-score-header"{% endif %}>
+                                {% translate "Score" %}
+                                <span
+                                    class="glyphicon glyphicon-info-sign"
+                                    data-toggle="tooltip"
+                                    data-placement="top"
+                                    title="{% translate 'Scores (0-100) are based on Repository stars, with deductions for inactivity (-10% every 3 months) and lack of Python 3 support (-30%).' %}"
+                                ></span>
                             </td>
-                        {% endfor %}
-                    </tr>
+                            {% for grid_package in grid_packages %}
+                                <td {% if TEST_MODE %}data-testid="grid-{{ grid_package.package.slug }}-detail-score-cell"{% endif %}>
+                                    {{ grid_package.package.score|intcomma|default:"n/a" }}
+                                </td>
+                            {% endfor %}
+                        </tr>
+                    {% endflag %}
                     <tr>
                         <td>{% translate "Repo Forks" %}</td>
                         {% for grid_package in grid_packages %}

--- a/templates/grid/grid_detail.html
+++ b/templates/grid/grid_detail.html
@@ -1,6 +1,6 @@
 {% extends "grid/base.html" %}
 
-{% load cache crispy_forms_tags emojificate grid_tags humanize i18n package_tags page_metadata_tags %}
+{% load cache crispy_forms_tags emojificate grid_tags humanize i18n package_tags page_metadata_tags static %}
 
 {% block metadata %}
     {% page_metadata page_title=grid.title page_description=grid.description page_keywords=grid.packages.all|join:',' og_image_url=grid.get_opengraph_image_url %}
@@ -104,7 +104,6 @@
                                         n/a
                                     {% endif %}
                                 {% endwith %}
-
                             </td>
                         {% endfor %}
                     </tr>
@@ -143,6 +142,20 @@
                         <td>{% translate "Stars" %}</td>
                         {% for grid_package in grid_packages %}
                             <td>{{ grid_package.package.repo_watchers|intcomma|default:"n/a" }}</td>
+                        {% endfor %}
+                    </tr>
+                    <tr>
+                        <td>
+                            {% translate "Score" %}
+                            <span
+                                class="glyphicon glyphicon-info-sign"
+                                data-toggle="tooltip"
+                                data-placement="top"
+                                title="{% translate 'Scores (0-100) are based on GitHub stars, with deductions for inactivity (-10% every 3 months) and lack of Python 3 support (-30%).' %}"
+                            ></span>
+                        </td>
+                        {% for grid_package in grid_packages %}
+                            <td>{{ grid_package.package.score|intcomma|default:"n/a" }}</td>
                         {% endfor %}
                     </tr>
                     <tr>
@@ -285,6 +298,11 @@
 
 {% endblock body %}
 
+{% block javascript %}
+    {{ block.super }}
+    <script src="{% static 'bower_components/bootstrap/dist/js/bootstrap.min.js' %}" defer></script>
+{% endblock javascript %}
+
 {% block extra_body %}
     <script type="text/javascript">
         $(function() {
@@ -355,6 +373,11 @@
 
             $("#filterForm").on("input", function() {
                 this.submit();
+            });
+
+            // Enable tooltips
+            $('[data-toggle="tooltip"]').tooltip({
+                container: 'body',
             });
         });
     </script>

--- a/templates/grid/grid_detail.html
+++ b/templates/grid/grid_detail.html
@@ -145,7 +145,7 @@
                         {% endfor %}
                     </tr>
                     <tr>
-                        <td>
+                        <td {% if TEST_MODE %}data-testid="grid-detail-score-header"{% endif %}>
                             {% translate "Score" %}
                             <span
                                 class="glyphicon glyphicon-info-sign"
@@ -155,7 +155,9 @@
                             ></span>
                         </td>
                         {% for grid_package in grid_packages %}
-                            <td>{{ grid_package.package.score|intcomma|default:"n/a" }}</td>
+                            <td {% if TEST_MODE %}data-testid="grid-{{ grid_package.package.slug }}-detail-score-cell"{% endif %}>
+                                {{ grid_package.package.score|intcomma|default:"n/a" }}
+                            </td>
                         {% endfor %}
                     </tr>
                     <tr>

--- a/templates/grid/grid_detail.html
+++ b/templates/grid/grid_detail.html
@@ -1,6 +1,6 @@
 {% extends "grid/base.html" %}
 
-{% load cache crispy_forms_tags emojificate grid_tags humanize i18n package_tags page_metadata_tags static %}
+{% load cache crispy_forms_tags emojificate grid_tags humanize i18n package_tags page_metadata_tags %}
 
 {% block metadata %}
     {% page_metadata page_title=grid.title page_description=grid.description page_keywords=grid.packages.all|join:',' og_image_url=grid.get_opengraph_image_url %}
@@ -300,7 +300,7 @@
 
 {% block javascript %}
     {{ block.super }}
-    <script src="{% static 'bower_components/bootstrap/dist/js/bootstrap.min.js' %}" defer></script>
+    <script src="{{ STATIC_URL }}bower_components/bootstrap/dist/js/bootstrap.min.js" defer></script>
 {% endblock javascript %}
 
 {% block extra_body %}

--- a/templates/package/package.html
+++ b/templates/package/package.html
@@ -348,7 +348,6 @@
     {{ block.super }}
     <script src="{{ STATIC_URL }}js/underscore.js" type="text/javascript"></script>
     <script src="{{ STATIC_URL }}js/gh3.js" type="text/javascript"></script>
-    <script src="{{ STATIC_URL }}bower_components/bootstrap/dist/js/bootstrap.min.js" defer></script>
 {% endblock javascript %}
 
 {% block extra_body %}
@@ -377,11 +376,6 @@
                     };
                 });
 
-            });
-
-            // Enable tooltips
-            $('[data-toggle="tooltip"]').tooltip({
-                container: 'body',
             });
         });
     </script>

--- a/templates/package/package.html
+++ b/templates/package/package.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load emojificate heroicons humanize i18n package_tags page_metadata_tags partials waffle_tags %}
+{% load emojificate heroicons humanize i18n package_tags page_metadata_tags partials waffle_tags static %}
 
 {% block metadata %}
     {% page_metadata page_title=package.title|emojify|emojificate page_description=package.repo_description page_keywords=package.grid_set.all|join:',' og_image_url=package.get_opengraph_image_url %}

--- a/templates/package/package.html
+++ b/templates/package/package.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load emojificate heroicons humanize i18n package_tags page_metadata_tags partials static waffle_tags %}
+{% load emojificate heroicons humanize i18n package_tags page_metadata_tags partials waffle_tags %}
 
 {% block metadata %}
     {% page_metadata page_title=package.title|emojify|emojificate page_description=package.repo_description page_keywords=package.grid_set.all|join:',' og_image_url=package.get_opengraph_image_url %}
@@ -341,7 +341,7 @@
     {{ block.super }}
     <script src="{{ STATIC_URL }}js/underscore.js" type="text/javascript"></script>
     <script src="{{ STATIC_URL }}js/gh3.js" type="text/javascript"></script>
-    <script src="{% static 'bower_components/bootstrap/dist/js/bootstrap.min.js' %}" defer></script>
+    <script src="{{ STATIC_URL }}bower_components/bootstrap/dist/js/bootstrap.min.js" defer></script>
 {% endblock javascript %}
 
 {% block extra_body %}

--- a/templates/package/package.html
+++ b/templates/package/package.html
@@ -133,16 +133,18 @@
                         >
                             {% translate "Commits" %}
                         </th>
-                        <th
-                            {% if TEST_MODE %}data-testid="repository-statistics-score-header"{% endif %}
-                            scope="col"
-                            data-toggle="tooltip"
-                            data-placement="top"
-                            aria-label="{% translate 'Score' %}"
-                            title="{% translate 'Scores (0-100) are based on Repository stars, with deductions for inactivity (-10% every 3 months) and lack of Python 3 support (-30%).' %}"
-                        >
-                            <span class="glyphicon glyphicon-stats"></span>
-                        </th>
+                        {% flag "enabled_packages_score_values" %}
+                            <th
+                                {% if TEST_MODE %}data-testid="repository-statistics-score-header"{% endif %}
+                                scope="col"
+                                data-toggle="tooltip"
+                                data-placement="top"
+                                aria-label="{% translate 'Score' %}"
+                                title="{% translate 'Scores (0-100) are based on Repository stars, with deductions for inactivity (-10% every 3 months) and lack of Python 3 support (-30%).' %}"
+                            >
+                                <span class="glyphicon glyphicon-stats"></span>
+                            </th>
+                        {% endflag %}
                         <th
                             scope="col"
                             data-toggle="tooltip"
@@ -169,9 +171,11 @@
                         <td>
                             {% include "package/includes/_commits.html" with value=package.commits_over_52 %}
                         </td>
-                        <td {% if TEST_MODE %}data-testid="repository-statistics-score-cell"{% endif %}>
-                            {{ package.score|intcomma|default:"n/a" }}
-                        </td>
+                        {% flag "enabled_packages_score_values" %}
+                            <td {% if TEST_MODE %}data-testid="repository-statistics-score-cell"{% endif %}>
+                                {{ package.score|intcomma|default:"n/a" }}
+                            </td>
+                        {% endflag %}
                         <td>{{ package.repo_watchers|intcomma|default:"n/a" }}</td>
                         <td>{{ package.repo_forks|intcomma|default:"n/a" }}</td>
                     </tr>

--- a/templates/package/package.html
+++ b/templates/package/package.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load emojificate heroicons humanize i18n package_tags page_metadata_tags partials waffle_tags static %}
+{% load emojificate heroicons humanize i18n package_tags page_metadata_tags partials static waffle_tags %}
 
 {% block metadata %}
     {% page_metadata page_title=package.title|emojify|emojificate page_description=package.repo_description page_keywords=package.grid_set.all|join:',' og_image_url=package.get_opengraph_image_url %}
@@ -138,7 +138,7 @@
                             data-toggle="tooltip"
                             data-placement="top"
                             aria-label="{% translate 'Score' %}"
-                            title="{% translate 'Scores (0-100) are based on GitHub stars, with deductions for inactivity (-10% every 3 months) and lack of Python 3 support (-30%).' %}"
+                            title="{% translate 'Scores (0-100) are based on Repository stars, with deductions for inactivity (-10% every 3 months) and lack of Python 3 support (-30%).' %}"
                         >
                             <span class="glyphicon glyphicon-stats"></span>
                         </th>
@@ -147,7 +147,7 @@
                             data-toggle="tooltip"
                             data-placement="top"
                             aria-label="{% translate 'Number of Stars' %}"
-                            title="{% translate 'Number of stars on GitHub' %}"
+                            title="{% translate 'Number of stars on the Repository.' %}"
                         >
                             <span class="glyphicon glyphicon-star"></span>
                         </th>
@@ -156,7 +156,7 @@
                             data-toggle="tooltip"
                             data-placement="top"
                             aria-label="{% translate 'Number of Forks' %}"
-                            title="{% translate 'Number of forks on GitHub' %}"
+                            title="{% translate 'Number of forks on the Repository.' %}"
                         >
                             <span class="glyphicon glyphicon-random"></span>
                         </th>

--- a/templates/package/package.html
+++ b/templates/package/package.html
@@ -134,6 +134,7 @@
                             {% translate "Commits" %}
                         </th>
                         <th
+                            {% if TEST_MODE %}data-testid="repository-statistics-score-header"{% endif %}
                             scope="col"
                             data-toggle="tooltip"
                             data-placement="top"
@@ -168,7 +169,9 @@
                         <td>
                             {% include "package/includes/_commits.html" with value=package.commits_over_52 %}
                         </td>
-                        <td>{{ package.score|intcomma|default:"n/a" }}</td>
+                        <td {% if TEST_MODE %}data-testid="repository-statistics-score-cell"{% endif %}>
+                            {{ package.score|intcomma|default:"n/a" }}
+                        </td>
                         <td>{{ package.repo_watchers|intcomma|default:"n/a" }}</td>
                         <td>{{ package.repo_forks|intcomma|default:"n/a" }}</td>
                     </tr>

--- a/templates/package/package.html
+++ b/templates/package/package.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load emojificate heroicons i18n package_tags page_metadata_tags partials static waffle_tags %}
+{% load emojificate heroicons humanize i18n package_tags page_metadata_tags partials static waffle_tags %}
 
 {% block metadata %}
     {% page_metadata page_title=package.title|emojify|emojificate page_description=package.repo_description page_keywords=package.grid_set.all|join:',' og_image_url=package.get_opengraph_image_url %}
@@ -109,33 +109,68 @@
 
     <!-- end Usage panel -->
     {% endcomment %}
-            <h2>Repo Activity
+            <h2>
+                {% translate "Repo Activity" %}
                 <div class="pull-right" id="fetch-cell">
                     {% if package.last_fetched %}
-                        <span class="small-text"> Last fetched: {{ package.last_fetched|timesince }} ago</span>&nbsp;
+                        <span class="small-text">{% translate "Last fetched" %}: {{ package.last_fetched|timesince }} ago</span>&nbsp;
                     {% endif %}
                     <a class="btn btn-default btn-xs"
                        href="{% url 'fetch_package_data' package.slug %}">{% translate "Fetch latest data" %}</a>
                 </div>
             </h2>
 
-            <table class="table">
+            <table class="table" aria-label="Repository Statistics">
                 <thead>
                     <tr>
-                        <th></th>
-                        <th>{% translate "Commits" %}</th>
-                        <th><span class="glyphicon glyphicon-star"></span></th>
-                        <th><span class="glyphicon glyphicon-random"></span></th>
+                        <th scope="col">Repository</th>
+                        <th
+                            scope="col"
+                            data-toggle="tooltip"
+                            data-placement="top"
+                            aria-label="{% translate 'History of commits in the last 52 weeks' %}"
+                            title="{% translate 'History of commits in the last 52 weeks' %}"
+                        >
+                            {% translate "Commits" %}
+                        </th>
+                        <th
+                            scope="col"
+                            data-toggle="tooltip"
+                            data-placement="top"
+                            aria-label="{% translate 'Score' %}"
+                            title="{% translate 'Scores (0-100) are based on GitHub stars, with deductions for inactivity (-10% every 3 months) and lack of Python 3 support (-30%).' %}"
+                        >
+                            <span class="glyphicon glyphicon-stats"></span>
+                        </th>
+                        <th
+                            scope="col"
+                            data-toggle="tooltip"
+                            data-placement="top"
+                            aria-label="{% translate 'Number of Stars' %}"
+                            title="{% translate 'Number of stars on GitHub' %}"
+                        >
+                            <span class="glyphicon glyphicon-star"></span>
+                        </th>
+                        <th
+                            scope="col"
+                            data-toggle="tooltip"
+                            data-placement="top"
+                            aria-label="{% translate 'Number of Forks' %}"
+                            title="{% translate 'Number of forks on GitHub' %}"
+                        >
+                            <span class="glyphicon glyphicon-random"></span>
+                        </th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
-                        <td><a href="{{ package.repo_url }}">{{ package.repo_url }}</a></td>
+                        <td scope="row"><a href="{{ package.repo_url }}">{{ package.repo_url }}</a></td>
                         <td>
                             {% include "package/includes/_commits.html" with value=package.commits_over_52 %}
                         </td>
-                        <td>{{ package.repo_watchers|default:"n/a" }}</td>
-                        <td>{{ package.repo_forks|default:"n/a" }}</td>
+                        <td>{{ package.score|intcomma|default:"n/a" }}</td>
+                        <td>{{ package.repo_watchers|intcomma|default:"n/a" }}</td>
+                        <td>{{ package.repo_forks|intcomma|default:"n/a" }}</td>
                     </tr>
                 </tbody>
             </table>
@@ -306,6 +341,7 @@
     {{ block.super }}
     <script src="{{ STATIC_URL }}js/underscore.js" type="text/javascript"></script>
     <script src="{{ STATIC_URL }}js/gh3.js" type="text/javascript"></script>
+    <script src="{% static 'bower_components/bootstrap/dist/js/bootstrap.min.js' %}" defer></script>
 {% endblock javascript %}
 
 {% block extra_body %}
@@ -336,6 +372,10 @@
 
             });
 
+            // Enable tooltips
+            $('[data-toggle="tooltip"]').tooltip({
+                container: 'body',
+            });
         });
     </script>
     <script src="{% static 'js/htmx.min.js' %}" defer></script>


### PR DESCRIPTION
**Description:**
Adding the "Score" to both the Grid and Package detail pages.

**Issue:**
https://github.com/djangopackages/djangopackages/issues/1063

**Screenshots:**
Grid Detail page:

https://github.com/user-attachments/assets/f7d6c037-c71d-4b67-b3ef-7112f88e5dc9





Package Detail page:

https://github.com/user-attachments/assets/ecafd97d-0268-4bb4-80c0-31a80250dfc1






**Open questions:**
1. Should I use the `{% static <path-to-asset>%}` or the {{ STATIC_URL }}? I saw places where one or the other is being used.
2. I'm not the biggest fan of testing HTML content without test markup, such as a `data-test-id` attribute in the tag, to avoid false positives and flakiness when asserting that the content I expected is in the correct place. Do you have any objections to adding it to this PR?
3. Can we move the Bootstrap.js import to our `base.html` template? By doing that, we use the Tooltip markup whenever we want without needing to import it every time.