### PR TITLE
🔥 Updates Codeberg User reference

### DIFF
--- a/package/repos/codeberg.py
+++ b/package/repos/codeberg.py
@@ -26,8 +26,7 @@ class ForgejoMetadata:
 class ForgejoCommit:
     sha: str
     created: str
-    # TODO: Consider adding this back, but user isn't used in our `Commit` model
-    # user: str | None
+    user: str | None
 
 
 class ForgejoClient:
@@ -90,7 +89,7 @@ class ForgejoClient:
                     yield ForgejoCommit(
                         sha=commit["sha"],
                         created=commit["created"],
-                        # user=commit["author"]["login"],
+                        user=commit["author"]["login"] if "author" in commit and commit["author"] else None,
                     )
                 except KeyError:
                     logger.error(f"no created timestamp for {url} with params {params}")

--- a/package/repos/codeberg.py
+++ b/package/repos/codeberg.py
@@ -26,7 +26,8 @@ class ForgejoMetadata:
 class ForgejoCommit:
     sha: str
     created: str
-    user: str
+    # TODO: Consider adding this back, but user isn't used in our `Commit` model
+    # user: str | None
 
 
 class ForgejoClient:
@@ -89,7 +90,7 @@ class ForgejoClient:
                     yield ForgejoCommit(
                         sha=commit["sha"],
                         created=commit["created"],
-                        user=commit["author"]["login"],
+                        # user=commit["author"]["login"],
                     )
                 except KeyError:
                     logger.error(f"no created timestamp for {url} with params {params}")

--- a/package/repos/codeberg.py
+++ b/package/repos/codeberg.py
@@ -89,7 +89,9 @@ class ForgejoClient:
                     yield ForgejoCommit(
                         sha=commit["sha"],
                         created=commit["created"],
-                        user=commit["author"]["login"] if "author" in commit and commit["author"] else None,
+                        user=commit["author"]["login"]
+                        if "author" in commit and commit["author"]
+                        else None,
                     )
                 except KeyError:
                     logger.error(f"no created timestamp for {url} with params {params}")


### PR DESCRIPTION
Fixes #1324

We are occasionally getting an error on `commit["author"]["login"]` because Codeberg is returning `None`. 
