### PR TITLE
fix(search): add description to search fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 *.py[co]
 
+#Python venv
+.venv
+venv
+
 # Packages
 *.egg
 *.egg-info

--- a/searchv2/tests/test_views.py
+++ b/searchv2/tests/test_views.py
@@ -42,8 +42,12 @@ class FunctionalPackageTest(TestCase):
 
     def test_search_function(self):
         build_1()
-        results = search_function("ser")
-        self.assertEqual(results[0].title, "Serious Testing")
+        results_1 = search_function("ser")
+        results_2 = search_function("wax")
+        self.assertEqual(results_1[0].title, "Serious Testing")
+        self.assertEqual(
+            results_2[0].description, "Make testing as painless as waxing your legs."
+        )
 
 
 class ViewTest(TestCase):

--- a/searchv2/views.py
+++ b/searchv2/views.py
@@ -45,6 +45,7 @@ def search_function(q: str, max_weight: int = 1):
                 | Q(title_no_prefix__startswith=q.lower())
                 | Q(slug__startswith=q.lower())
                 | Q(slug_no_prefix__startswith=q.lower())
+                | Q(description__icontains=q)
             )
             .annotate(weight_as_float=Cast("weight", output_field=FloatField()))
             .annotate(


### PR DESCRIPTION
- **What does this PR do?**

This PR updates the search_function in searchv2/views.py to also consider the description field when searching for packages. Currently, searches like "inline" do not match packages (such as django-nested-admin) that have this term in their description.

- Issue
Fixes: #1257

- Changes
  --- Updated the search_function in searchv2/views.py:
            Added `Q(description__icontains=q) `to the filter.
  --- Updated the test_search_function in searchv2/tests/test_views.py.
    
 ```results_1 = search_function("ser")
 results_2 = search_function("wax")
 self.assertEqual(results_1[0].title, "Serious Testing")
 self.assertEqual(
        results_2[0].description, "Make testing as painless as waxing your legs."
  )```
