### PR TITLE
:sparkles: Show Django 6.0/5.2 and Python 3.14/3.15 counts

### DIFF
--- a/homepage/views.py
+++ b/homepage/views.py
@@ -28,6 +28,8 @@ class OpenView(TemplateView):
             "total_django_4_2": "Framework :: Django :: 4.2",
             "total_django_5_0": "Framework :: Django :: 5.0",
             "total_django_5_1": "Framework :: Django :: 5.1",
+            "total_django_5_2": "Framework :: Django :: 5.2",
+            "total_django_6_0": "Framework :: Django :: 6.0",
             "total_python_2_7": "Programming Language :: Python :: 2.7",
             "total_python_3": "Programming Language :: Python :: 3",
             "total_python_3_6": "Programming Language :: Python :: 3.6",
@@ -38,6 +40,8 @@ class OpenView(TemplateView):
             "total_python_3_11": "Programming Language :: Python :: 3.11",
             "total_python_3_12": "Programming Language :: Python :: 3.12",
             "total_python_3_13": "Programming Language :: Python :: 3.13",
+            "total_python_3_14": "Programming Language :: Python :: 3.14",
+            "total_python_3_15": "Programming Language :: Python :: 3.15",
         }
         vcs_providers = {
             "repos_bitbucket": "bitbucket.org",

--- a/templates/pages/open.html
+++ b/templates/pages/open.html
@@ -38,22 +38,23 @@
             </div>
             <div class="col-sm-6 col-md-3">
                 <h2>{% translate "Django Versions" %}</h2>
+                <p>{% translate "Django 6.0 Packages:" %} {{ total_django_6_0|intcomma }}</p>
+                <p>{% translate "Django 5.2 Packages:" %} {{ total_django_5_2|intcomma }}</p>
                 <p>{% translate "Django 5.1 Packages:" %} {{ total_django_5_1|intcomma }}</p>
                 <p>{% translate "Django 5.0 Packages:" %} {{ total_django_5_0|intcomma }}</p>
                 <p>{% translate "Django 4.2 Packages:" %} {{ total_django_4_2|intcomma }}</p>
-                <p>{% translate "Django 4.1 Packages:" %} {{ total_django_4_1|intcomma }}</p>
                 <p>{% translate "Django 3.2 Packages:" %} {{ total_django_3_2|intcomma }}</p>
                 <p>{% translate "Django 2.2 Packages:" %} {{ total_django_2_2|intcomma }}</p>
             </div>
             <div class="col-sm-6 col-md-3">
                 <h2>{% translate "Python Versions" %}</h2>
                 <p>{% translate "Python 3 Packages:" %} {{ total_python_3|intcomma }}</p>
+                <p>{% translate "Python 3.15 Packages:" %} {{ total_python_3_15|intcomma }}</p>
+                <p>{% translate "Python 3.14 Packages:" %} {{ total_python_3_14|intcomma }}</p>
                 <p>{% translate "Python 3.13 Packages:" %} {{ total_python_3_13|intcomma }}</p>
                 <p>{% translate "Python 3.12 Packages:" %} {{ total_python_3_12|intcomma }}</p>
                 <p>{% translate "Python 3.11 Packages:" %} {{ total_python_3_11|intcomma }}</p>
                 <p>{% translate "Python 3.10 Packages:" %} {{ total_python_3_10|intcomma }}</p>
-                <p>{% translate "Python 3.9 Packages:" %} {{ total_python_3_9|intcomma }}</p>
-                <p>{% translate "Python 3.8 Packages:" %} {{ total_python_3_8|intcomma }}</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Overall goal is to add Django 6.0/5.2 and Python 3.14/3.15 counts to our open pages. 

- [x] WIP but will touch one file #1418 is working with. 