### PR TITLE
fix(homepage): prevent URL overflow in package description cards

### DIFF
--- a/templates/_homepage.html
+++ b/templates/_homepage.html
@@ -33,8 +33,7 @@ This is a hack to keep the next set of divs from wrapping up and making the disp
                 <div class="text-center categories col-sm-3">
                     <h2 class="panel-title">{{ category.title_plural }} </h2>
                     <p>{{ category.description|widont }}</p>
-                    <a href="{% url 'category' category.slug %}" class="btn btn-primary">Show {{ category.title_plural }} ({{
-                        category.package_count|intcomma }})</a>
+                    <a href="{% url 'category' category.slug %}" class="btn btn-primary">Show {{ category.title_plural }} ({{ category.package_count|intcomma }})</a>
                 </div>
             {% endif %}
         {% endfor %}


### PR DESCRIPTION
Fixes the text overflow issue where long URLs in package descriptions overflow outside their container cards on the homepage. Fixes #1425. 