### PR TITLE
Add django-health-check for /health/ endpoint

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,7 @@ django-crispy-forms<3
 django-debug-toolbar
 django-environ
 django-extensions
+django-health-check
 django-htmx
 django-jsonview
 django-maintenance-mode

--- a/requirements.txt
+++ b/requirements.txt
@@ -413,6 +413,7 @@ django==5.1.13 \
     #   django-crispy-forms
     #   django-debug-toolbar
     #   django-extensions
+    #   django-health-check
     #   django-htmx
     #   django-picklefield
     #   django-q2
@@ -457,6 +458,10 @@ django-environ==0.12.0 \
 django-extensions==3.2.3 \
     --hash=sha256:44d27919d04e23b3f40231c4ab7af4e61ce832ef46d610cc650d53e68328410a \
     --hash=sha256:9600b7562f79a92cbf1fde6403c04fee314608fefbb595502e34383ae8203401
+    # via -r requirements.in
+django-health-check==3.20.0 \
+    --hash=sha256:bcb2b8f36f463cead0564a028345c5b17e2a2d18e9cc88ecd611b13a26521926 \
+    --hash=sha256:cd69ac5facf73fe7241d9492d939b57bd20e24f46c4edea91e6a900bf22c2d8e
     # via -r requirements.in
 django-htmx==1.23.0 \
     --hash=sha256:71e6242ac6bd32a0e14fcb12b340f901c9a924f0b4e9b461a5e6a6eea8d9c6dd \

--- a/settings.py
+++ b/settings.py
@@ -211,6 +211,12 @@ PREREQ_APPS = [
     "django_q",
     "template_partials",
     "anymail",
+    # health checks
+    "health_check",
+    "health_check.db",
+    "health_check.cache",
+    "health_check.storage",
+    "health_check.contrib.redis",
 ]
 
 INSTALLED_APPS = PREREQ_APPS + PROJECT_APPS

--- a/urls.py
+++ b/urls.py
@@ -50,6 +50,7 @@ urlpatterns = [
         name="robots_txt",
     ),
     path("health_check/", health_check_view, name="health_check"),
+    path("health/", include("health_check.urls")),
     path("404", error_404_view, name="404"),
     path("500", error_500_view, name="500"),
     path("503", error_503_view, name="503"),


### PR DESCRIPTION
- Added django-health-check to requirements.in
- Configured health check apps in settings.py:
  - health_check (core)
  - health_check.db (database checks)
  - health_check.cache (cache checks)
  - health_check.storage (storage checks)
  - health_check.contrib.redis (redis checks)
- Added /health/ URL endpoint in urls.py
- Tested endpoint successfully with all checks working

Fixes #1438