### PR TITLE
:fire: Remove unused Celery settings

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -22,7 +22,6 @@ TEST_SETTINGS = {
             "LOCATION": "unique-snowflake",
         },
     },
-    "CELERY_TASK_ALWAYS_EAGER": True,
     "EMAIL_BACKEND": "django.core.mail.backends.locmem.EmailBackend",
     "LOGGING_CONFIG": None,
     "PASSWORD_HASHERS": ["django.contrib.auth.hashers.MD5PasswordHasher"],

--- a/settings.py
+++ b/settings.py
@@ -100,14 +100,6 @@ SEARCHV2_HEALTHCHECK_URL = env.str("SEARCHV2_HEALTHCHECK_URL", "")
 # Configure Redis
 REDIS_HOST = env("REDIS_HOST", default="redis")
 
-# Configure Celery
-CELERY_BROKER_URL = f"redis://{REDIS_HOST}:6379"
-CELERY_RESULT_BACKEND = f"redis://{REDIS_HOST}:6379"
-CELERY_ACCEPT_CONTENT = ["application/json"]
-CELERY_TASK_SERIALIZER = "json"
-CELERY_RESULT_SERIALIZER = "json"
-CELERY_TIMEZONE = "UTC"
-
 
 # Use the default admin media prefix, which is...
 # ADMIN_MEDIA_PREFIX = "/static/admin/"


### PR DESCRIPTION
## Summary
- Remove unused Celery configuration from `settings.py` (6 settings)
- Remove `CELERY_TASK_ALWAYS_EAGER` from test settings in `conftest.py`

The project uses Django-Q (`qcluster`) for task processing, not Celery. These settings were leftover from a previous configuration and Celery is not installed in `pyproject.toml`.