### PR TITLE
Enable database connection pooling

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -356,15 +356,14 @@ LOGIN_REDIRECT_URL = "/"
 # Raises ImproperlyConfigured exception if DATABASE_URL not in os.environ
 DATABASES = {"default": env.db("DATABASE_URL")}
 # DATABASES["default"] = env.db("DATABASE_URL")
-# DATABASES["default"]["DISABLE_SERVER_SIDE_CURSORS"] = True
-# DATABASES["default"]["CONN_HEALTH_CHECKS"] = True
-# DATABASES["default"]["OPTIONS"] = {
-#     "pool": {
-#         "min_size": 2,
-#         "max_size": 10,
-#         "timeout": 10,
-#     }
-# }
+DATABASES["default"]["CONN_HEALTH_CHECKS"] = True
+DATABASES["default"]["OPTIONS"] = {
+    "pool": {
+        "min_size": 4,
+        "max_size": 20,
+        "timeout": 10,
+    }
+}
 
 ########## END DATABASE CONFIGURATION
 


### PR DESCRIPTION
## Summary
- Enable `CONN_HEALTH_CHECKS` for connection validation
- Configure connection pool with `min_size: 4`, `max_size: 20`, `timeout: 10`
- Keep gunicorn at 4 workers × 4 threads (16 max) to match pool capacity
- Django-Q uses 4 workers, giving total of 20 potential connections