### PR TITLE
Fix Timesheet Style

### DIFF
--- a/templates/grid/grid_timesheet.html
+++ b/templates/grid/grid_timesheet.html
@@ -8,6 +8,21 @@
 
 {% block extra_head %}
     <link href="{% static 'css/timesheet.css' %}" media="all" rel="stylesheet" />
+    <style>
+        /* Keep large grids from overflowing the page */
+        .timesheet-scroll {
+            width: 100%;
+            overflow-x: auto;
+            overflow-y: hidden;
+            -webkit-overflow-scrolling: touch;
+        }
+
+        #timesheet.timesheet .data {
+            height: calc(100% - 28px);
+            overflow-y: auto;
+            overflow-x: hidden;
+        }
+    </style>
 {% endblock extra_head %}
 
 {% block content %}
@@ -34,7 +49,9 @@
 
         <div class="card">
             <div class="p-6 card-content">
-                <div id="timesheet"></div>
+                <div class="timesheet-scroll">
+                    <div id="timesheet"></div>
+                </div>
             </div>
         </div>
     </div>
@@ -44,7 +61,7 @@
     <script src="{% static 'js/timesheet.js' %}" type="text/javascript"></script>
     <script type="text/javascript">
         {% now "Y" as current_year %}
-        new Timesheet('timesheet', {{ current_year|add:"-7" }}, {{ current_year }}, [
+        new Timesheet('timesheet', {{ current_year|add:"-5" }}, {{ current_year }}, [
             {% for grid_package in grid_packages %}
                 {% with package=grid_package.package %}
                     ['{{ package.created|date:"m/Y" }}', '{{ package.last_updated|date:"m/Y" }}', '{{ package.slug }}', ''],


### PR DESCRIPTION
The Timesheet.js library is not responsive, had to add some custom CSS for this, now it supports scrolling.

<img width="1612" height="787" alt="Screenshot 2026-01-13 at 12 33 51 AM" src="https://github.com/user-attachments/assets/fa01a56e-e2ac-42bd-85d1-2bfc141d74aa" />

Fixes: https://github.com/djangopackages/djangopackages/issues/1488