### PR TITLE
:bug: Fix KeyError for show_features in cached grid payloads

### DIFF
--- a/grid/views.py
+++ b/grid/views.py
@@ -345,7 +345,7 @@ class GridDetailView(DetailView):
                 "filter_data": filter_data,
                 "total_package_count": payload["total_package_count"],
                 "has_more_packages": payload["has_more_packages"],
-                "show_features": payload["show_features"],
+                "show_features": payload.get("show_features", True),
                 "max_packages": self.max_packages,
             }
         )


### PR DESCRIPTION
## Summary
- Fix `KeyError: 'show_features'` when viewing grids with stale cached data
- Use `.get("show_features", True)` to gracefully handle old cached payloads that were created before the `show_features` key was added
- Add tests verifying features are shown/hidden based on the 8-package threshold