### PR TITLE
Bump gunicorn workers to 6 and django-q workers to 4

### DIFF
--- a/dockerfiles/django/start-web.sh
+++ b/dockerfiles/django/start-web.sh
@@ -24,5 +24,5 @@ uv run -m manage migrate --noinput
 uv run gunicorn \
     wsgi:application \
     --bind 0.0.0.0:8000 \
-    --workers 4 \
+    --workers 6 \
     --threads 4

--- a/settings.py
+++ b/settings.py
@@ -515,7 +515,7 @@ Q_CLUSTER = {
     "timeout": 600,  # this won't work for longer running tasks that might take hours to run
     "retry": 700,
     "max_attempts": 1,
-    "workers": 2,
+    "workers": 4,
 }
 
 if Q_REDIS_URL := env("Q_REDIS_URL", default=None):


### PR DESCRIPTION
## Summary
- Increase gunicorn workers from 4 to 6
- Increase django-q workers from 2 to 4
- Better utilizes 4 CPU / 16GB machine resources