### PR TITLE
Fix #1373 -- Add support for PEP 639 license_expression field

### DIFF
--- a/package/models.py
+++ b/package/models.py
@@ -420,9 +420,10 @@ class Package(BaseModel):
                         print(e)
 
                 # do we have a license set?
-                if "license" in info and info["license"]:
-                    license = normalize_license(info["license"])
-                    # TODO: revisit this
+                # Prefer "license_expression" (PEP 639) over "license" (legacy)
+                license_value = info.get("license_expression") or info.get("license")
+                if license_value:
+                    license = normalize_license(license_value)
                     licenses = [license]
                     for classifier in info["classifiers"]:
                         if classifier.startswith("License"):


### PR DESCRIPTION
Hey there! 👋 

I stumbled upon the issue #1373 when checking https://djangopackages.org/packages/p/django-devbar/ - the license shows as `UNKNOWN` while in fact being correctly set on [PyPI](https://pypi.org/project/django-devbar/) and [GitHub](https://github.com/amureki/django-devbar).

I figured the piece where the problem lies, however I'm not sure if my PR is covering everything (for example, I noticed a "TODO" comment there, while I don't know what that was about).

Feel free to alter the code or leave feedback about this work, I am happy to address the concerns myself.

Thanks again for maintaining such a great project!

Cheers,
Rust

