### PR TITLE
Redesign Opengraph Image for Package and Grid Detail Pages

### DIFF
--- a/grid/urls.py
+++ b/grid/urls.py
@@ -1,6 +1,7 @@
 """grid url patterns"""
 
 from django.urls import path, re_path
+from django.views.decorators.cache import cache_page
 
 from grid.views import (
     AddGridView,
@@ -83,7 +84,7 @@ urlpatterns = [
     ),
     path(
         "g/<slug:slug>/opengraph/",
-        view=GridOpenGraphView.as_view(),
+        view=cache_page(60 * 60 * 24)(GridOpenGraphView.as_view()),
         name="grid_opengraph",
     ),
     path(

--- a/package/urls.py
+++ b/package/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path, re_path
+from django.views.decorators.cache import cache_page
 
 from package.views import (
     LatestPackageListView,
@@ -91,7 +92,7 @@ urlpatterns = [
     ),
     path(
         "p/<slug:slug>/opengraph/",
-        view=PackageOpenGraphDetailView.as_view(),
+        view=cache_page(60 * 60 * 24)(PackageOpenGraphDetailView.as_view()),
         name="package_opengraph",
     ),
     path(

--- a/templates/grid/grid_opengraph.html
+++ b/templates/grid/grid_opengraph.html
@@ -2,23 +2,32 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" integrity="sha512-1ycn6IcaQQ40/MKBW2W4Rhis/DbILU74C1vSrLJxCq57o941Ym01SwNsOMqvEBFlcgUa6xLiPY/NS5R+E6ztJQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
         <script src="https://cdn.tailwindcss.com"></script>
     </head>
-    <body class="">
-        <div class="static absolute w-[1200px] h-[630px] bg-[#44b78b]">
-            <main class="px-32 pt-12">
-                <div class="text-6xl font-bold text-white">Grid :: {{ grid.title }}</div>
-                <div class="pt-8 text-4xl text-green-100">{{ grid.description }}</div>
+    <body class="font-sans antialiased">
+        <div class="flex relative flex-col justify-between w-[1200px] h-[630px] bg-[oklch(0.98_0_0)]">
+            <div class="w-full h-4 bg-[oklch(0.3176_0.0648_159.21)]"></div>
+            <main class="flex-1 px-24 pt-24">
+                <div class="inline-flex items-center py-2 px-6 mb-8 text-xl font-bold rounded-full border-2 border-[oklch(0.3176_0.0648_159.21)] bg-[oklch(0.3176_0.0648_159.21)]/10 text-[oklch(0.3176_0.0648_159.21)]">
+                    Grid
+                </div>
+                <h1 class="mb-6 text-7xl font-bold tracking-tight leading-tight text-[oklch(0.15_0_0)] line-clamp-2">
+                    {{ grid.title }}
+                </h1>
+                <p class="text-4xl leading-normal text-[oklch(0.45_0_0)] line-clamp-3">
+                    {{ grid.description }}
+                </p>
             </main>
-            <footer class="absolute bottom-0 left-0 w-full">
-                <section class="py-8 px-32">
-                    <div class="text-2xl text-gray-900">https://djangogrids.org{% url "grid" slug=grid.slug %}</div>
-                </section>
-                <section class="flex flex-row py-4 px-32 text-white bg-black">
-                    <span class="flex-none self-center"><img src="https://djangopackages.org/static/img/logo_squares.png" alt="[[Django Packages Logo]]"></span>
-                    <span class="flex-1 self-center pl-4 text-7xl text-white">Django Packages</span>
-                </section>
+            <div class="px-24 pb-10">
+                <div class="text-2xl font-medium text-[oklch(0.45_0_0)]">
+                    https://djangogrids.org{% url "grid" slug=grid.slug %}
+                </div>
+            </div>
+            <footer class="py-8 bg-[oklch(0.3176_0.0648_159.21)]">
+                <div class="flex gap-6 justify-center items-center">
+                    <img src="https://djangopackages.org/static/img/logo_squares.png" alt="Django Packages" class="w-auto h-14 brightness-0 invert">
+                    <span class="text-5xl font-bold leading-none text-white">Django Packages</span>
+                </div>
             </footer>
         </div>
     </body>

--- a/templates/package/package_opengraph.html
+++ b/templates/package/package_opengraph.html
@@ -5,20 +5,30 @@
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" integrity="sha512-1ycn6IcaQQ40/MKBW2W4Rhis/DbILU74C1vSrLJxCq57o941Ym01SwNsOMqvEBFlcgUa6xLiPY/NS5R+E6ztJQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
         <script src="https://cdn.tailwindcss.com"></script>
     </head>
-    <body class="">
-        <div class="static absolute w-[1200px] h-[630px] bg-[#44b78b]">
-            <main class="px-32 pt-12">
-                <div class="text-6xl font-bold text-white">Package :: {{ package.title }}</div>
-                <div class="pt-8 text-4xl text-green-100">{{ package.repo_description }}</div>
+    <body class="font-sans antialiased">
+        <div class="flex relative flex-col justify-between w-[1200px] h-[630px] bg-[oklch(0.98_0_0)]">
+            <div class="w-full h-4 bg-[oklch(0.3176_0.0648_159.21)]"></div>
+            <main class="flex-1 px-24 pt-24">
+                <div class="inline-flex items-center py-2 px-6 mb-8 text-xl font-bold rounded-full border-2 border-[oklch(0.3176_0.0648_159.21)] bg-[oklch(0.3176_0.0648_159.21)]/10 text-[oklch(0.3176_0.0648_159.21)]">
+                    Package
+                </div>
+                <h1 class="mb-6 text-7xl font-bold tracking-tight leading-tight text-[oklch(0.15_0_0)] line-clamp-2">
+                    {{ package.title }}
+                </h1>
+                <p class="text-4xl leading-normal text-[oklch(0.45_0_0)] line-clamp-3">
+                    {{ package.repo_description }}
+                </p>
             </main>
-            <footer class="absolute bottom-0 left-0 w-full">
-                <section class="py-8 px-32">
-                    <div class="text-2xl text-gray-900">https://djangopackages.org{% url "package" slug=package.slug %}</div>
-                </section>
-                <section class="flex flex-row py-4 px-32 text-white bg-black">
-                    <span class="flex-none self-center"><img src="https://djangopackages.org/static/img/logo_squares.png" alt="[[Django Packages Logo]]"></span>
-                    <span class="flex-1 self-center pl-4 text-7xl text-white">Django Packages</span>
-                </section>
+            <div class="px-24 pb-10">
+                <div class="text-2xl font-medium text-[oklch(0.45_0_0)]">
+                    https://djangopackages.org{% url "package" slug=package.slug %}
+                </div>
+            </div>
+            <footer class="py-8 bg-[oklch(0.3176_0.0648_159.21)]">
+                <div class="flex gap-6 justify-center items-center">
+                    <img src="https://djangopackages.org/static/img/logo_squares.png" alt="Django Packages" class="w-auto h-14 brightness-0 invert">
+                    <span class="text-5xl font-bold leading-none text-white">Django Packages</span>
+                </div>
             </footer>
         </div>
     </body>


### PR DESCRIPTION
closes https://github.com/djangopackages/djangopackages/issues/1509

**Package Detail:**
<img width="1501" height="789" alt="Screenshot 2026-01-22 at 7 57 20 PM" src="https://github.com/user-attachments/assets/069206c2-582c-4753-9978-1e1ae0855d19" />

**Grid Detail:**
<img width="1502" height="792" alt="Screenshot 2026-01-22 at 7 57 39 PM" src="https://github.com/user-attachments/assets/f2ff2eb8-a58e-4221-b9aa-027d0f7f129e" />
