### PR TITLE
Fix link style in post detail and list templates

### DIFF
--- a/templates/blog/post_detail.html
+++ b/templates/blog/post_detail.html
@@ -32,7 +32,7 @@
                     </div>
                 </div>
 
-                <div class="max-w-none prose prose-lg text-foreground dark:prose-invert">
+                <div class="max-w-none prose prose-lg text-muted-foreground">
                     {{ post.content|markdown }}
                 </div>
             </div>

--- a/templates/blog/post_list.html
+++ b/templates/blog/post_list.html
@@ -41,7 +41,7 @@
                                     </a>
                                 </h2>
                             </div>
-                            <div class="max-w-none md:w-2/3 prose prose-sm text-muted-foreground dark:prose-invert">
+                            <div class="max-w-none md:w-2/3 prose prose-sm text-muted-foreground">
                                 {{ post.content|markdown }}
                             </div>
                         </div>


### PR DESCRIPTION
Links were not visible:

<img width="1102" height="257" alt="Screenshot 2026-01-23 at 5 55 01 PM" src="https://github.com/user-attachments/assets/d4e50ec5-ea44-4f95-b446-59248fe8ee2f" />
