### PR TITLE
Fix upload time handling in Package model and related rules

### DIFF
--- a/package/models.py
+++ b/package/models.py
@@ -275,7 +275,7 @@ class Package(BaseModel):
 
     @property
     def pypi_ancient(self):
-        if version := self.latest_version:
+        if (version := self.latest_version) and version.upload_time:
             return version.upload_time < now() - timedelta(365)
         return None
 

--- a/package/tests/test_models_v2.py
+++ b/package/tests/test_models_v2.py
@@ -1,5 +1,6 @@
 from package.scores import update_package_score
 import pytest
+from model_bakery import baker
 
 
 def test_category(category):
@@ -107,3 +108,12 @@ def test_package_example(package_example):
 
     # check that pacages are not active by default
     assert package_example.active is None
+
+
+def test_package_pypi_ancient_none_when_upload_time_missing(category):
+    package = baker.make("package.Package", category=category)
+    version = baker.make("package.Version", package=package, upload_time=None)
+    package.latest_version = version
+    package.save(update_fields=["latest_version"])
+
+    assert package.pypi_ancient is None

--- a/searchv2/builders.py
+++ b/searchv2/builders.py
@@ -48,12 +48,12 @@ def calc_package_weight(*, package: Package) -> int:
             weight += min(usage_count, 20)
 
         # Is the last release less than a year old?
-        try:
-            if last_released := package.latest_version:
-                if now - last_released.upload_time < timedelta(365):
-                    weight += 20
-        except AttributeError:
-            ...
+        if (
+            (last_released := package.latest_version)
+            and last_released.upload_time
+            and now - last_released.upload_time < timedelta(365)
+        ):
+            weight += 20
 
     # Is there ongoing work or is this forgotten?
     if last_updated := package.last_commit_date:

--- a/searchv2/rules.py
+++ b/searchv2/rules.py
@@ -329,22 +329,20 @@ class RecentReleaseRule(ScoreRule):
         Returns a full score and a success message if the last release is recent,
         or a zero score and an error message otherwise.
         """
-        try:
-            last_released = package.latest_version
-            now = timezone.now()
-            if now - last_released.upload_time < timedelta(365):
-                return CheckResult(
-                    score=self.max_score,
-                    message="Last release is less than a year old.",
-                )
-            else:
-                return CheckResult(
-                    score=0, message="Last release is more than a year old."
-                )
-        except AttributeError:
+        last_released = package.latest_version
+        if not last_released or not last_released.upload_time:
             return CheckResult(
                 score=0, message="No release data found for the package."
             )
+
+        now = timezone.now()
+        if now - last_released.upload_time < timedelta(365):
+            return CheckResult(
+                score=self.max_score,
+                message="Last release is less than a year old.",
+            )
+
+        return CheckResult(score=0, message="Last release is more than a year old.")
 
 
 class UsageCountRule(ScoreRule):

--- a/searchv2/tests/test_builders.py
+++ b/searchv2/tests/test_builders.py
@@ -72,6 +72,26 @@ def test_calc_package_weight(db, faker):
     assert calc_package_weight(package=package) == 0
 
 
+def test_calc_package_weight_handles_null_latest_version_upload_time(db):
+    category = baker.make("package.Category")
+    package = baker.make(
+        "package.Package",
+        category=category,
+        documentation_url="https://example.com/docs",
+        repo_description="Some package",
+        repo_forks=0,
+        repo_watchers=0,
+        pypi_downloads=0,
+        last_commit_date=None,
+    )
+    version = baker.make("package.Version", package=package, upload_time=None)
+    package.latest_version = version
+    package.save(update_fields=["latest_version"])
+
+    weight = calc_package_weight(package=package)
+    assert weight == 40
+
+
 def test_package_score_after_build(db):
     package = baker.make("package.Package", score=600)
     build_1()

--- a/searchv2/tests/test_rules.py
+++ b/searchv2/tests/test_rules.py
@@ -1,0 +1,34 @@
+from django.utils import timezone
+from model_bakery import baker
+
+from searchv2.rules import RecentReleaseRule
+
+
+def test_recent_release_rule_handles_null_upload_time(db):
+    category = baker.make("package.Category")
+    package = baker.make("package.Package", category=category)
+    version = baker.make("package.Version", package=package, upload_time=None)
+    package.latest_version = version
+    package.save(update_fields=["latest_version"])
+
+    result = RecentReleaseRule().check(package=package)
+
+    assert result.score == 0
+    assert result.message == "No release data found for the package."
+
+
+def test_recent_release_rule_scores_recent_release(db):
+    category = baker.make("package.Category")
+    package = baker.make("package.Package", category=category)
+    version = baker.make(
+        "package.Version",
+        package=package,
+        upload_time=timezone.now() - timezone.timedelta(days=30),
+    )
+    package.latest_version = version
+    package.save(update_fields=["latest_version"])
+
+    result = RecentReleaseRule().check(package=package)
+
+    assert result.score == RecentReleaseRule().max_score
+    assert result.message == "Last release is less than a year old."


### PR DESCRIPTION
**Fix upload time handling in Package model and related rules**

- Update pypi_ancient property to check for upload_time before comparison.
- Refactor RecentReleaseRule to handle cases with missing upload_time.
- Enhance calc_package_weight to account for null latest_version upload_time.
- Add tests for handling null upload_time in package scoring rules.

Sentry Issue: https://django-packages.sentry.io/issues/7265235642/events/a5d84990284a43be97bee9a8d5997258/