### PR TITLE
Support multiple simultaneous site banners

### DIFF
--- a/banners/cache.py
+++ b/banners/cache.py
@@ -2,27 +2,27 @@ from django.conf import settings
 from django.core.cache import cache
 from banners.models import Banner
 
-BANNER_CACHE_KEY = "banners:active_banner"
+BANNER_CACHE_KEY = "banners:active_banners"
 
-# A sentinel distinct from None so we can cache a "no banner" result.
+# A sentinel distinct from None so we can cache a "no banners" result.
 # cache.get() returns None by default when a key is missing, which would be
-# indistinguishable from a cached "no active banner" (None).  Using a private
+# indistinguishable from a cached "no active banners" (None).  Using a private
 # sentinel lets us tell the difference: _CACHE_MISS means "not in cache yet",
-# None means "cache says there is no active banner right now".
+# None means "cache says there are no active banners right now".
 _CACHE_MISS = object()
 
 
-def get_active_banner():
-    """Return the active banner, using cache when available."""
-    banner = cache.get(BANNER_CACHE_KEY, _CACHE_MISS)
+def get_active_banners():
+    """Return all active banners, using cache when available."""
+    banners = cache.get(BANNER_CACHE_KEY, _CACHE_MISS)
 
-    if banner is _CACHE_MISS:
-        banner = Banner.objects.active().first()
-        cache.set(BANNER_CACHE_KEY, banner, timeout=settings.CACHE_TIMEOUT)
+    if banners is _CACHE_MISS:
+        banners = list(Banner.objects.active())
+        cache.set(BANNER_CACHE_KEY, banners, timeout=settings.CACHE_TIMEOUT)
 
-    return banner
+    return banners
 
 
 def invalidate_banner_cache():
-    """Delete the cached active banner."""
+    """Delete the cached active banners."""
     cache.delete(BANNER_CACHE_KEY)

--- a/banners/context_processors.py
+++ b/banners/context_processors.py
@@ -1,13 +1,9 @@
-from banners.cache import get_active_banner
+from banners.cache import get_active_banners
 
 
 def active_banner(request):
-    """Add the current active banner to the template context.
-
-    Skips banners that the user has already dismissed (stored in their session).
-    """
-    banner = get_active_banner()
-    if banner and (session := getattr(request, "session", {})):
-        if session.get(f"dismissed_banner_{banner.pk}"):
-            banner = None
-    return {"active_banner": banner}
+    """Add active banners to the template context, excluding dismissed ones."""
+    banners = get_active_banners()
+    if banners and (session := getattr(request, "session", {})):
+        banners = [b for b in banners if not session.get(f"dismissed_banner_{b.pk}")]
+    return {"active_banners": banners}

--- a/banners/tests/test_context_processors.py
+++ b/banners/tests/test_context_processors.py
@@ -11,7 +11,7 @@ from banners.models import Banner
 
 @pytest.mark.django_db
 class TestBannerContextProcessor:
-    def test_active_banner_in_context(self):
+    def test_active_banners_in_context(self):
         banner = baker.make(
             Banner,
             title="Active Banner",
@@ -20,12 +20,30 @@ class TestBannerContextProcessor:
         )
         request = RequestFactory().get("/")
         context = active_banner(request)
-        assert context["active_banner"] == banner
+        assert banner in context["active_banners"]
 
-    def test_no_active_banner_in_context(self):
+    def test_multiple_active_banners_in_context(self):
+        banner1 = baker.make(
+            Banner,
+            title="Banner 1",
+            start_date=timezone.now() - datetime.timedelta(hours=2),
+            end_date=None,
+        )
+        banner2 = baker.make(
+            Banner,
+            title="Banner 2",
+            start_date=timezone.now() - datetime.timedelta(hours=1),
+            end_date=None,
+        )
         request = RequestFactory().get("/")
         context = active_banner(request)
-        assert context["active_banner"] is None
+        assert banner1 in context["active_banners"]
+        assert banner2 in context["active_banners"]
+
+    def test_no_active_banners_in_context(self):
+        request = RequestFactory().get("/")
+        context = active_banner(request)
+        assert context["active_banners"] == []
 
     def test_expired_banner_not_in_context(self):
         now = timezone.now()
@@ -37,7 +55,7 @@ class TestBannerContextProcessor:
         )
         request = RequestFactory().get("/")
         context = active_banner(request)
-        assert context["active_banner"] is None
+        assert context["active_banners"] == []
 
     def test_dismissed_banner_excluded_from_context(self):
         """A banner dismissed in the session should not appear in context."""
@@ -50,4 +68,24 @@ class TestBannerContextProcessor:
         request = RequestFactory().get("/")
         request.session = {f"dismissed_banner_{banner.pk}": True}
         context = active_banner(request)
-        assert context["active_banner"] is None
+        assert banner not in context["active_banners"]
+
+    def test_only_dismissed_banner_excluded_when_multiple_active(self):
+        """Only the dismissed banner is filtered out; others still show."""
+        kept = baker.make(
+            Banner,
+            title="Kept Banner",
+            start_date=timezone.now() - datetime.timedelta(hours=2),
+            end_date=None,
+        )
+        dismissed = baker.make(
+            Banner,
+            title="Dismissed Banner",
+            start_date=timezone.now() - datetime.timedelta(hours=1),
+            end_date=None,
+        )
+        request = RequestFactory().get("/")
+        request.session = {f"dismissed_banner_{dismissed.pk}": True}
+        context = active_banner(request)
+        assert kept in context["active_banners"]
+        assert dismissed not in context["active_banners"]

--- a/templates/partials/banner.html
+++ b/templates/partials/banner.html
@@ -8,7 +8,7 @@
         <div class="container flex gap-3 items-center py-3 px-4 mx-auto">
             <div class="flex-1 min-w-0">
                 <p
-                    class="text-sm font-medium text-foreground/90 leading-loose {% if banner.alignment == 'center' %} text-center {% elif banner.alignment == 'right' %} text-right {% endif %}"
+                    class="text-sm font-medium text-foreground/90 leading-loose [&_a]:underline [&_a]:underline-offset-2 [&_a]:hover:opacity-75 {% if banner.alignment == 'center' %} text-center {% elif banner.alignment == 'right' %} text-right {% endif %}"
                 >
                     {% if banner.banner_type == 'sponsored' %}
                         <span

--- a/templates/partials/banner.html
+++ b/templates/partials/banner.html
@@ -1,16 +1,16 @@
-{% if active_banner %}
+{% for banner in active_banners %}
     <div
-        id="site-banner"
-        data-banner-id="{{ active_banner.pk }}"
+        id="site-banner-{{ banner.pk }}"
+        data-banner-id="{{ banner.pk }}"
         role="alert"
-        class="border-b {% if active_banner.banner_type == 'sponsored' %} bg-violet-50 border-violet-200 {% elif active_banner.banner_type == 'notice' %} bg-sky-50 border-sky-200 {% elif active_banner.banner_type == 'success' %} bg-emerald-50 border-emerald-200 {% elif active_banner.banner_type == 'warning' %} bg-amber-50 border-amber-200 {% elif active_banner.banner_type == 'critical' %} bg-red-50 border-red-200 {% endif %}"
+        class="border-b {% if banner.banner_type == 'sponsored' %} bg-violet-50 border-violet-200 {% elif banner.banner_type == 'notice' %} bg-sky-50 border-sky-200 {% elif banner.banner_type == 'success' %} bg-emerald-50 border-emerald-200 {% elif banner.banner_type == 'warning' %} bg-amber-50 border-amber-200 {% elif banner.banner_type == 'critical' %} bg-red-50 border-red-200 {% endif %}"
     >
         <div class="container flex gap-3 items-center py-3 px-4 mx-auto">
             <div class="flex-1 min-w-0">
                 <p
-                    class="text-sm font-medium text-foreground/90 leading-loose {% if active_banner.alignment == 'center' %} text-center {% elif active_banner.alignment == 'right' %} text-right {% endif %}"
+                    class="text-sm font-medium text-foreground/90 leading-loose {% if banner.alignment == 'center' %} text-center {% elif banner.alignment == 'right' %} text-right {% endif %}"
                 >
-                    {% if active_banner.banner_type == 'sponsored' %}
+                    {% if banner.banner_type == 'sponsored' %}
                         <span
                             class="inline-flex gap-1 items-center py-0.5 px-2 mr-2 font-semibold tracking-wide text-violet-700 uppercase align-middle bg-violet-100 rounded-full border border-violet-200 text-[11px]"
                         >
@@ -19,26 +19,27 @@
                         </span>
                     {% else %}
                         <i
-                            class="inline align-middle mr-1 text-base ph-bold {{ active_banner.display_icon }}
-                                   {% if active_banner.banner_type == 'notice' %}
+                            class="inline align-middle mr-1 text-base ph-bold {{ banner.display_icon }}
+                                   {% if banner.banner_type == 'notice' %}
                                        text-sky-600
-                                   {% elif active_banner.banner_type == 'success' %}
+                                   {% elif banner.banner_type == 'success' %}
                                        text-emerald-600
-                                   {% elif active_banner.banner_type == 'warning' %}
+                                   {% elif banner.banner_type == 'warning' %}
                                        text-amber-600
-                                   {% elif active_banner.banner_type == 'critical' %}
+                                   {% elif banner.banner_type == 'critical' %}
                                        text-red-600
                                    {% endif %}
                                   "
                         ></i>
-                    {% endif %} {{ active_banner.content|safe }}
+                    {% endif %} {{ banner.content|safe }}
                 </p>
             </div>
-        {# Dismiss button: right corner #} {% if active_banner.is_dismissible %}
+            {# Dismiss button: right corner #}
+            {% if banner.is_dismissible %}
                 <button
                     type="button"
-                    hx-post="{% url 'banners:dismiss' active_banner.pk %}"
-                    hx-target="#site-banner"
+                    hx-post="{% url 'banners:dismiss' banner.pk %}"
+                    hx-target="#site-banner-{{ banner.pk }}"
                     hx-swap="outerHTML"
                     hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
                     class="inline-flex flex-shrink-0 justify-center items-center w-6 h-6 rounded-md transition-colors text-muted-foreground hover:text-foreground hover:bg-foreground/5"
@@ -49,4 +50,4 @@
             {% endif %}
         </div>
     </div>
-{% endif %}
+{% endfor %}


### PR DESCRIPTION
Getting ready to exercise this a bit. 

## Summary

- `get_active_banner()` → `get_active_banners()` — now returns a list of all active banners instead of just the first one
- Context processor passes `active_banners` (list) to templates; dismissed banners are filtered out individually from the list
- `banner.html` loops over `active_banners`; each banner gets a unique `id="site-banner-{{ banner.pk }}"` so HTMX dismiss targets the correct one
- Updated tests to cover multiple simultaneous banners and partial dismissal
- Style anchor tags in banner content with underline