### PR TITLE
Replace manual `uv` bootstrap with Read the Docs native `uv` support

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,15 +11,13 @@ mkdocs:
   configuration: docs/mkdocs.yml
 
 build:
-   os: ubuntu-24.04
-   tools:
-      python: "3.12"
-   jobs:
-      pre_create_environment:
-         - asdf plugin add uv
-         - asdf install uv latest
-         - asdf global uv latest
-      create_environment:
-         - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
-      install:
-         - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --group docs
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+python:
+  install:
+    - method: uv
+      command: sync
+      groups:
+        - docs


### PR DESCRIPTION
Ref: https://about.readthedocs.com/blog/2026/04/uv-native-support/