### PR TITLE
:arrow_up: Bump j178/prek-action from v1.0.6 to v2

### DIFF
--- a/.github/workflows/prek-autoupdate.yml
+++ b/.github/workflows/prek-autoupdate.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install prek
-        uses: j178/prek-action@v1.0.6
+        uses: j178/prek-action@v2
         with:
           install-only: true
 

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -10,4 +10,4 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - uses: actions/checkout@v6.0.1
-            - uses: j178/prek-action@v1.0.6
+            - uses: j178/prek-action@v2


### PR DESCRIPTION
Bumps `j178/prek-action` from v1.0.6 to v2 in both workflow files.