### PR TITLE
Fix RTD build: switch to uv run via build.commands

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,15 @@ formats: all
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.14"
-  commands:
-    - uv sync --group docs
-    - uv run mkdocs build --clean --site-dir $READTHEDOCS_OUTPUT/html --config-file docs/mkdocs.yml
+    python: "3.12"
+  jobs:
+    build:
+      html:
+        - $READTHEDOCS_VIRTUALENV_PATH/bin/python -m mkdocs build --clean --site-dir $READTHEDOCS_OUTPUT/html --config-file docs/mkdocs.yml
+
+python:
+  install:
+    - method: uv
+      command: sync
+      groups:
+        - docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ formats: all
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.14"
   jobs:
     build:
       html:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,18 +7,16 @@ version: 2
 
 formats: all
 
+# Set the version of Python and other tools you might need
 build:
   os: ubuntu-24.04
   tools:
     python: "3.14"
-  jobs:
-    build:
-      html:
-        - $READTHEDOCS_VIRTUALENV_PATH/bin/python -m mkdocs build --clean --site-dir $READTHEDOCS_OUTPUT/html --config-file docs/mkdocs.yml
 
+mkdocs:
+  configuration: docs/mkdocs.yml
+
+# Optionally declare the Python requirements required to build your docs
 python:
   install:
-    - method: uv
-      command: sync
-      groups:
-        - docs
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,4 +19,8 @@ mkdocs:
 # Optionally declare the Python requirements required to build your docs
 python:
   install:
-    - requirements: docs/requirements.txt
+    # - requirements: docs/requirements.txt
+    - method: uv
+      command: sync
+      groups:
+        - docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,17 +7,10 @@ version: 2
 
 formats: all
 
-mkdocs:
-  configuration: docs/mkdocs.yml
-
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.12"
-
-python:
-  install:
-    - method: uv
-      command: sync
-      groups:
-        - docs
+    python: "3.14"
+  commands:
+    - uv sync --group docs
+    - uv run mkdocs build --clean --site-dir $READTHEDOCS_OUTPUT/html --config-file docs/mkdocs.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,8 +19,8 @@ mkdocs:
 # Optionally declare the Python requirements required to build your docs
 python:
   install:
-    # - requirements: docs/requirements.txt
-    - method: uv
-      command: sync
-      groups:
-        - docs
+    - requirements: docs/requirements.txt
+    # - method: uv
+    #   command: sync
+    #   groups:
+    #     - docs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs
+mkdocs-material
+mkdocstrings[python]


### PR DESCRIPTION
## Summary

- RTD's native uv support (`method: uv, command: sync`) installs dependencies correctly but then invokes `python -m mkdocs build` using `/bin/python`, which doesn't exist on Ubuntu 24.04
- Switches to `build.commands` with `uv run mkdocs build` so uv handles venv activation — no `/bin/python` lookup involved
- Also bumps the Python tool version to `3.14` to match the RTD blog post example