### PR TITLE
Replace manual uv bootstrap with Read the Docs native uv support

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,20 +7,17 @@ version: 2
 
 formats: all
 
-# Set the version of Python and other tools you might need
-build:
-  os: ubuntu-24.04
-  tools:
-    python: "3.14"
-
 mkdocs:
   configuration: docs/mkdocs.yml
 
-# Optionally declare the Python requirements required to build your docs
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
 python:
   install:
-    - requirements: docs/requirements.txt
-    # - method: uv
-    #   command: sync
-    #   groups:
-    #     - docs
+    - method: uv
+      command: sync
+      groups:
+        - docs

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -58,7 +58,7 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          paths: [../searchv3]
+          paths: [..]
           options:
             # More options are located at https://mkdocstrings.github.io/python/usage/configuration/general/
             # General

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,0 @@
-mkdocs
-mkdocs-material
-mkdocstrings[python]


### PR DESCRIPTION
closes: https://github.com/djangopackages/djangopackages/issues/1595

Retrying this as https://github.com/readthedocs/readthedocs.org/issues/12996 has been fix fixed.