### PR TITLE
Fix `/health/` -> `500` by configuring the Redis check for `django-health-check` `4.x`

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -41,3 +41,5 @@ CACHES = {
         "BACKEND": "django.core.cache.backends.dummy.DummyCache",
     }
 }
+
+REDIS_URL = "redis://localhost:6379/0"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,20 @@
+from unittest.mock import AsyncMock, patch
+
+from django.test import override_settings
+
+LOCMEM_CACHES = {
+    "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}
+}
+
+
+@override_settings(CACHES=LOCMEM_CACHES, REDIS_URL="redis://localhost:6379/0")
+def test_health_endpoint(db, tp):
+    with patch("redis.asyncio.Redis.ping", new_callable=AsyncMock):
+        response = tp.client.get("/health/", headers={"accept": "application/json"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "Cache(alias='default')": "OK",
+        "Database(alias='default')": "OK",
+        "Redis(db=0, host='localhost', port=6379)": "OK",
+    }

--- a/urls.py
+++ b/urls.py
@@ -6,6 +6,7 @@ from django.urls import include, path, re_path
 from django.views.decorators.cache import cache_page
 from django.views.generic.base import RedirectView, TemplateView
 from health_check.views import HealthCheckView
+from redis.asyncio import Redis as RedisClient
 
 from blog.sitemaps import BlogSitemap
 from core import __version__
@@ -45,6 +46,19 @@ handler500 = "homepage.views.error_500_view"
 handler403 = "homepage.views.error_403_view"
 handler503 = "homepage.views.error_503_view"
 
+health_checks = [
+    "health_check.Cache",
+    "health_check.Database",
+]
+
+if settings.REDIS_URL:
+    health_checks.append(
+        (
+            "health_check.contrib.redis.Redis",
+            {"client_factory": lambda: RedisClient.from_url(settings.REDIS_URL)},
+        )
+    )
+
 urlpatterns = [
     # url(r'^login/\{\{item\.absolute_url\}\}/', RedirectView.as_view(url="/login/github/")),
     path("auth/", include("social_django.urls", namespace="social")),
@@ -62,13 +76,7 @@ urlpatterns = [
     ),
     path(
         "health/",
-        HealthCheckView.as_view(
-            checks=[
-                "health_check.Cache",
-                "health_check.Database",
-                "health_check.contrib.redis.Redis",
-            ]
-        ),
+        HealthCheckView.as_view(checks=health_checks),
     ),
     path("404", error_404_view, name="404"),
     path("403", error_403_view, name="403"),


### PR DESCRIPTION
While investigating a [Sentry issue](https://djangopackages.sentry.io/issues/7376044436/events/d4bd47db3fd6448cb7a5b9feabefe3c3/) I found that every request to `/health/` has been returning a 500 since [#1581](https://github.com/djangopackages/djangopackages/pull/1581) bumped django-health-check from 3.20 to 4.x. The new version's Redis check no longer reads `REDIS_URL` from settings and raises a `ValueError` at instantiation unless it's given a `client_factory`, and the upgrade left it registered without one, crashing the whole endpoint on every request. I've configured the check the way the 4.x docs recommend.

**Ref:** 

1. https://django-packages.sentry.io/issues/7376044436/events/d4bd47db3fd6448cb7a5b9feabefe3c3/
2. https://github.com/codingjoe/django-health-check/issues/632

