### PR TITLE
Fix GitHub Login Issue (`social-app-django` 6.0 breaking change)

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -227,7 +227,7 @@ ABSOLUTE_URL_OVERRIDES = {
 
 AUTH_PROFILE_MODULE = "profiles.Profile"
 
-LOGIN_URL = "/auth/login/github/"
+LOGIN_URL = "/login/"
 LOGIN_REDIRECT_URLNAME = "home"
 LOGOUT_REDIRECT_URL = "/"
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+{% load i18n page_metadata_tags %}
+
+{% block metadata %}
+    {% translate "Log In" as trans_title %}
+    {% page_metadata page_title=trans_title %}
+{% endblock metadata %}
+
+{% block content %}
+    <!-- Breadcrumb Section -->
+    <section class="py-4 bg-primary/10">
+        <div class="container px-4 mx-auto">
+            <div class="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-center">
+                <div class="flex items-center text-sm text-muted-foreground">
+                    <a href="{% url 'home' %}" class="hover:underline">{% translate "Home" %}</a>
+                    <span class="mx-2">»</span>
+                    <span class="font-medium text-foreground truncate">{% translate "Log In" %}</span>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <div class="container py-8 px-4 mx-auto">
+        <div class="mb-8">
+            <h1 class="text-3xl font-bold text-foreground">{% translate "Log In" %}</h1>
+            <p class="pt-2 text-muted-foreground">{% translate "Log in with your GitHub account to continue." %}</p>
+        </div>
+
+        <div class="max-w-3xl card">
+            <div class="p-6 card-content">
+                <form method="post" action="{% url 'social:begin' 'github' %}">
+                    {% csrf_token %}
+                    {% if request.GET.next %}
+                        <input type="hidden" name="next" value="{{ request.GET.next }}">
+                    {% endif %}
+                    <div>
+                        <button type="submit" class="w-full md:w-auto btn-primary">
+                            <i class="mr-1 text-lg ph-bold ph-github-logo"></i>
+                            {% translate "Log In with GitHub" %}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -110,12 +110,15 @@
                     {% translate "Log Out" %}
                 </a>
             {% else %}
-                <a
-                    href="{% url 'social:begin' 'github' %}"
-                    class="hidden justify-center items-center px-3 h-9 text-sm font-semibold rounded-md border transition-colors lg:inline-flex focus:ring-2 focus:outline-none text-primary-foreground/90 bg-primary-foreground/10 border-primary-foreground/20 hover:text-primary-foreground hover:bg-primary-foreground/15 hover:border-primary-foreground/30 focus:ring-primary-foreground/30"
-                >
-                    {% translate "Log In" %}
-                </a>
+                <form method="post" action="{% url 'social:begin' 'github' %}" class="hidden lg:block">
+                    {% csrf_token %}
+                    <button
+                        type="submit"
+                        class="inline-flex justify-center items-center px-3 h-9 text-sm font-semibold rounded-md border transition-colors focus:ring-2 focus:outline-none text-primary-foreground/90 bg-primary-foreground/10 border-primary-foreground/20 hover:text-primary-foreground hover:bg-primary-foreground/15 hover:border-primary-foreground/30 focus:ring-primary-foreground/30"
+                    >
+                        {% translate "Log In" %}
+                    </button>
+                </form>
             {% endif %}
 
             <!-- Mobile menu button -->
@@ -196,7 +199,10 @@
                 {% endif %}
                 <a href="{% url 'logout' %}" class="block py-2 px-3 text-base font-medium rounded-md transition-colors text-primary-foreground/80 hover:text-primary-foreground hover:bg-primary-foreground/5">{% translate "Log Out" %}</a>
             {% else %}
-                <a href="{% url 'social:begin' 'github' %}" class="block py-2 px-3 text-base font-medium rounded-md transition-colors text-primary-foreground/80 hover:text-primary-foreground hover:bg-primary-foreground/5">{% translate "Log In" %}</a>
+                <form method="post" action="{% url 'social:begin' 'github' %}">
+                    {% csrf_token %}
+                    <button type="submit" class="block py-2 px-3 w-full text-base font-medium text-left rounded-md transition-colors text-primary-foreground/80 hover:text-primary-foreground hover:bg-primary-foreground/5">{% translate "Log In" %}</button>
+                </form>
             {% endif %}
         </nav>
     </div>

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -22,6 +22,29 @@ def test_help(db, tp):
     assert response.status_code == 200
 
 
+def test_login(db, tp):
+    url = tp.reverse("login")
+    response = tp.client.get(url)
+    assert response.status_code == 200
+    assert b'<form method="post" action="/auth/login/github/">' in response.content
+
+
+def test_login_carries_next_as_hidden_input(db, tp):
+    url = tp.reverse("login")
+    response = tp.client.get(url, {"next": "/profiles/edit/"})
+    assert response.status_code == 200
+    assert (
+        b'<input type="hidden" name="next" value="/profiles/edit/">' in response.content
+    )
+
+
+def test_login_required_view_redirects_to_login(db, tp):
+    url = tp.reverse("profile_edit")
+    response = tp.client.get(url)
+    assert response.status_code == 302
+    assert response["Location"] == "/login/?next=/profiles/edit/"
+
+
 def test_open(db, tp):
     from package.models import Category
 

--- a/urls.py
+++ b/urls.py
@@ -93,7 +93,11 @@ urlpatterns = [
         "categories/<slug:slug>/", PackageByCategoryListView.as_view(), name="category"
     ),
     path("categories/", HomepageView.as_view(), name="categories"),
-    # url(regex=r'^login/$', view=TemplateView.as_view(template_name='pages/login.html'), name='login',),
+    path(
+        "login/",
+        TemplateView.as_view(template_name="login.html"),
+        name="login",
+    ),
     path("logout/", LogoutView.as_view(), name="logout"),
     # static pages
     path("about/", TemplateView.as_view(template_name="faq.html"), name="about"),


### PR DESCRIPTION
`social-auth-app-django` **6.0** added a breaking change that made the login views POST-only, so every GET path into `/auth/login/github/` (navbar links, `login_required` redirects etc.) now returns HTTP 405.

- Replaced the navbar "Log In" links (desktop and mobile) with forms that POST to `social:begin` with a CSRF token.
- Added a static `/login/` page in `urls.py` that renders the same form. Redirects can only GET, so `login_required` needs a page that carries the POST form. It passes `?next=` through as a hidden input.
- Pointed `LOGIN_URL` at `/login/`.

**Reference:**

> ### Breaking
> - Login views now always require POST requests, and the `SOCIAL_AUTH_REQUIRE_POST` setting was removed.

https://github.com/python-social-auth/social-app-django/blob/master/CHANGELOG.md#breaking