### PR TITLE
fix raw template variable in README badge code

### DIFF
--- a/package/tests/test_views.py
+++ b/package/tests/test_views.py
@@ -44,6 +44,15 @@ class FunctionalPackageTest(TestCase):
             "Scores (0-100) are based on Repository stars",
         )
 
+    def test_package_detail_renders_readme_badge(self):
+        url = reverse("package", kwargs={"slug": "testability"})
+        response = self.client.get(url)
+
+        self.assertContains(
+            response,
+            "[![Latest on Django Packages](https://img.shields.io/badge/PyPI-testability-tags-8c3c26.svg)](https://djangopackages.org/packages/p/testability/)",
+        )
+
     @override_flag("enabled_packages_score_values", active=False)
     @pytest.mark.deprecated(
         """

--- a/templates/package/package_detail.html
+++ b/templates/package/package_detail.html
@@ -481,8 +481,7 @@
                             {% translate "If you're the maintainer of this project, publicize Django Packages by adding the badge to your README!" %}
                         </p>
                         <div class="bg-muted overflow-wrap-anywhere mb-3 rounded p-3 font-mono text-xs break-words">
-                            [![Latest on Django Packages](https://img.shields.io/badge/PyPI-{{ package.slug
-                            }}-tags-8c3c26.svg)](https://djangopackages.org{{ package.get_absolute_url }})
+                            [![Latest on Django Packages](https://img.shields.io/badge/PyPI-{{ package.slug }}-tags-8c3c26.svg)](https://djangopackages.org{{ package.get_absolute_url }})
                         </div>
                         <button id="copy-badge-btn" class="btn-secondary w-full">
                             <i class="ph-bold ph-copy mr-2 text-base" id="copy-icon"></i>


### PR DESCRIPTION
A newline in the `{{ package.slug }}` template variable causes the example code to contain the raw template variable text instead of the package's actual slug.

<img width="498" height="331" alt="image" src="https://github.com/user-attachments/assets/e7af05d8-e553-4402-a983-59a5afc6161b" />

Note: it might be nice to render the badge above the div containing the code, to show an example of what it looks like. Left that out of this bugfix PR for now.